### PR TITLE
One configurable source...

### DIFF
--- a/src/main/java/io/rcktapp/rql/elasticsearch/QueryDsl.java
+++ b/src/main/java/io/rcktapp/rql/elasticsearch/QueryDsl.java
@@ -123,6 +123,15 @@ public class QueryDsl extends ElasticQuery
    }
 
    /**
+    * @return the sources
+    */
+   @JsonIgnore
+   public List<String> getSources()
+   {
+      return source;
+   }
+
+   /**
     * @return the range
     */
    public Range getRange()


### PR DESCRIPTION
If only one source is requested, that source can now be returned as an
array instead of a list of objects.  If no source is listed, the server
will fallback to a default source value if available.

Two server side settings are used for this.
'defaultSource' = "json"
'isOneSrcArray' = true