### PR TITLE
Added sw,w,ew functions to RQL (previously only worked for RQL->Elastic

### DIFF
--- a/src/main/java/io/rcktapp/rql/Stmt.java
+++ b/src/main/java/io/rcktapp/rql/Stmt.java
@@ -351,6 +351,37 @@ public class Stmt
             sql.append(term1).append(" = ").append(term2);
          }
       }
+      else if ("w".equalsIgnoreCase(token)) 
+      {
+         String term1 = terms.get(0);
+         String term2 = terms.get(1);
+         
+         int firstQuoteIndex = term2.indexOf("'") + 1;
+         int lastQuoteIndex = term2.lastIndexOf("'");
+         term2 = term2.substring(0, firstQuoteIndex) + '%' + term2.substring(firstQuoteIndex, lastQuoteIndex) + '%' + term2.substring(lastQuoteIndex) ;
+         
+         sql.append(term1).append(" LIKE ").append(term2);
+      }
+      else if ("sw".equalsIgnoreCase(token)) 
+      {
+         String term1 = terms.get(0);
+         String term2 = terms.get(1);
+         
+         int lastQuoteIndex = term2.lastIndexOf("'");
+         term2 = term2.substring(0, lastQuoteIndex) + '%' + term2.substring(lastQuoteIndex) ;
+
+         sql.append(term1).append(" LIKE ").append(term2);
+      }
+      else if ("ew".equalsIgnoreCase(token)) 
+      {
+         String term1 = terms.get(0);
+         String term2 = terms.get(1);
+         
+         int firstQuoteIndex = term2.indexOf("'") + 1;
+         term2 = term2.substring(0, firstQuoteIndex) + '%' + term2.substring(firstQuoteIndex) ;
+
+         sql.append(term1).append(" LIKE ").append(term2);
+      }
       else if ("ne".equalsIgnoreCase(token))
       {
          String term1 = terms.get(0);

--- a/src/test/java/io/rcktapp/rql/RqlToElasticSearchTest.java
+++ b/src/test/java/io/rcktapp/rql/RqlToElasticSearchTest.java
@@ -94,6 +94,38 @@ public class RqlToElasticSearchTest
          fail();
       }
    }
+   
+   @Test
+   public void with()
+   {
+      try
+      {
+         QueryDsl dsl = new RQL("elastic").toQueryDsl(split("w(city,andl)"));
+
+         assertNull(dsl.getBool());
+         assertNull(dsl.getNested());
+         assertNull(dsl.getNestedPath());
+         assertNull(dsl.getRange());
+         assertNull(dsl.getTerm());
+         assertNotNull(dsl.getWildcard());
+
+         assertEquals("city", dsl.getWildcard().getName());
+         assertEquals("*andl*", dsl.getWildcard().getValue());
+         assertNull(dsl.getWildcard().getNestedPath());
+
+         ObjectMapper mapper = new ObjectMapper();
+         String json = mapper.writeValueAsString(dsl);
+
+         assertNotNull("json should not be empty.", json);
+         assertEquals("{\"wildcard\":{\"city\":\"*andl*\"}}", json);
+
+      }
+      catch (Exception e)
+      {
+         log.debug("derp! ", e);
+         fail();
+      }
+   }
 
    @Test
    public void endsWith()

--- a/src/test/java/io/rcktapp/rql/RqlToSqlTest.java
+++ b/src/test/java/io/rcktapp/rql/RqlToSqlTest.java
@@ -107,6 +107,21 @@ public class RqlToSqlTest
                             "select * from table1", //
                             "select `firstName`, `lastName`, SUM(`age`), MAX(`height`) AS 'tallest', MIN(`height`) AS 'shortest' from table1 WHERE `firstName` = 'Wells' AND `lastName` = 'Burke' GROUP BY `firstName`, `lastName`", //
                             null));
+      
+      tests.add(new RqlTest("w(city,andl)", //
+            "select * from table1", //
+            "select * from table1 WHERE `city` LIKE '%andl%'", //
+            null));
+      
+      tests.add(new RqlTest("sw(city,andl)", //
+            "select * from table1", //
+            "select * from table1 WHERE `city` LIKE 'andl%'", //
+            null));
+      
+      tests.add(new RqlTest("ew(city,andl)", //
+            "select * from table1", //
+            "select * from table1 WHERE `city` LIKE '%andl'", //
+            null));
 
       tests.add(new RqlTest("in(firstName,wells,joe,karl)", //
                             "select * from table1", //


### PR DESCRIPTION
'w' converts to `field` LIKE '%value%'
'sw' converts to `field` LIKE 'value%'
'ew' converts to `field` LIKE '%value'