### PR TITLE
Fixed: single source requests and 'null' prevStart values

### DIFF
--- a/src/main/java/io/rcktapp/rql/RQL.java
+++ b/src/main/java/io/rcktapp/rql/RQL.java
@@ -167,7 +167,7 @@ public class RQL
             query.setSearchAfter(searchAfterList);
          }
 
-         // remove the prevStart param if it exists...it wont be used.
+         // use this value if wantedpage was not set; prevents having to lookup the prev value...of course.
          params.remove("prevstart");
       }
 

--- a/src/main/java/io/rcktapp/rql/elasticsearch/QueryDsl.java
+++ b/src/main/java/io/rcktapp/rql/elasticsearch/QueryDsl.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -52,6 +53,9 @@ public class QueryDsl extends ElasticQuery
 
    @JsonIgnore
    private List<String> searchAfter;
+
+   @JsonIgnore
+   private String       prevStart;
 
    @JsonIgnore
    private List<String> source;
@@ -186,15 +190,32 @@ public class QueryDsl extends ElasticQuery
    /**
     * @param searchAfter the searchAfter to set
     */
-   public void setSearchAfter(List<String> searchAfter)
+   public void setPreviousStart(String prev)
    {
-      this.searchAfter = searchAfter;
+      this.prevStart = prev;
+   }
+
+   @JsonIgnore
+   public String getPreviousStart()
+   {
+      return this.prevStart;
    }
 
    @JsonIgnore
    public boolean isSearchAfterNull()
    {
       return searchAfter == null;
+   }
+   
+   public void setSearchAfter(List<String> searchAfter)
+   {
+      this.searchAfter = searchAfter;
+   }
+
+   @JsonIgnore
+   public String getSearchAfterAsString()
+   {
+      return this.searchAfter.stream().map(String::valueOf).collect(Collectors.joining(","));
    }
 
    /**


### PR DESCRIPTION
Previously, at least two sources were required in order for an elastic
query to work properly.  That has been fixed.

While fixing the above, I noticed that the prevStart request parameter
was not being set properly on the 'next' meta property.  This has also
been fixed.