### PR TITLE
Fixed: MySql idle timeout

### DIFF
--- a/src/main/java/io/rcktapp/api/Db.java
+++ b/src/main/java/io/rcktapp/api/Db.java
@@ -29,6 +29,7 @@ public class Db extends Dto
    String           pass    = null;
    int              poolMin = 3;
    int              poolMax = 10;
+   int              idleConnectionTestPeriod = 3600; // in seconds
    ArrayList<Table> tables  = new ArrayList();
 
    public Db()
@@ -207,6 +208,16 @@ public class Db extends Dto
    public void setPoolMax(int poolMax)
    {
       this.poolMax = poolMax;
+   }
+   
+   public int getIdleConnectionTestPeriod()
+   {
+      return idleConnectionTestPeriod;
+   }
+
+   public void setIdleConnectionTestPeriod(int idleConnectionTestPeriod)
+   {
+      this.idleConnectionTestPeriod = idleConnectionTestPeriod;
    }
 
 }

--- a/src/main/java/io/rcktapp/api/service/Service.java
+++ b/src/main/java/io/rcktapp/api/service/Service.java
@@ -923,6 +923,7 @@ public class Service extends HttpServlet
                      String password = db.getPass();
                      int minPoolSize = db.getPoolMin();
                      int maxPoolSize = db.getPoolMax();
+                     int idleTestPeriod = db.getIdleConnectionTestPeriod();
 
                      minPoolSize = Math.max(MIN_POOL_SIZE, minPoolSize);
                      maxPoolSize = Math.min(maxPoolSize, MAX_POOL_SIZE);
@@ -934,6 +935,10 @@ public class Service extends HttpServlet
                      pool.setPassword(password);
                      pool.setMinPoolSize(minPoolSize);
                      pool.setMaxPoolSize(maxPoolSize);
+                     
+                     pool.setIdleConnectionTestPeriod(idleTestPeriod);
+                     //                     if (idleTestPeriod > 0)
+                     //                        pool.setTestConnectionOnCheckin(true);
 
                      pools.put(db, pool);
                   }


### PR DESCRIPTION
Added an idle check that defaults to once an hour.  Evidently, by default, MySQL kills idle connections after 8Hrs.

Added configuration to liftck_snooze