### PR TITLE
Fixed: Redirects

### DIFF
--- a/src/main/java/io/rcktapp/api/service/Service.java
+++ b/src/main/java/io/rcktapp/api/service/Service.java
@@ -290,6 +290,11 @@ public class Service
                   res.setContentType("text/text");
             }
          }
+         else if (!J.empty(res.getRedirect()))
+         {
+            res.addHeader("Location", res.getRedirect());
+            res.setStatus("302 Found");
+         }
          else if (output == null && res.getJson() != null)
          {
             output = res.getJson().toString();
@@ -445,12 +450,6 @@ public class Service
                String redirect = req.getUrl().toString();
                //redirect = req.getHttpServletRequest().getRequest
                redirect = redirect.replaceFirst("\\/" + collection, "\\/" + plural);
-
-               String queryString = req.getUrl().getQuery();
-               if (!J.empty(queryString))
-               {
-                  redirect += "?" + queryString;
-               }
 
                res.setRedirect(redirect);
                return true;


### PR DESCRIPTION
Several CORS headers are sent back to the client which did not exist with 0.2.x.  Previously, 4 headers were returned to the client when a redirect occurred: 
Content-Length, 
Date, 
X-Application-Context, 
Location.

0.3.x includes 8 headers: 
Access-Control-Allow-Credentials, 
Access-Control-Allow-Headers,
Access-Control-Allow-Methods, 
Access-Control-Allow-Origin, 
Date, 
X-Application-Context, 
Transfer-Encoding, 
Location.

I was unsure if the the CORS headers should be removed.