### PR TITLE
Kf/20190430 session timeout fix

### DIFF
--- a/src/main/java/io/rcktapp/api/handler/security/AuthHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/security/AuthHandler.java
@@ -223,19 +223,20 @@ public class AuthHandler implements Handler
 
       if (user != null)
       {
+         // update the session cache if this is a session request OR 
+         // if the session update time has passed.
          boolean updateSessionCache = false;
          long previousReqTime = user.getRequestAt();
-         long diff = now - previousReqTime;
-         if (diff > sessionUpdate || (now == previousReqTime))
+         if (now - previousReqTime > sessionUpdate)
             updateSessionCache = true;
 
          user.setRequestAt(now);
          req.setUser(user);
 
-         sessionKey = req.getApi().getId() + "_" + newSessionId();//
 
          if (sessionReq && req.isPost())
          {
+            sessionKey = req.getApi().getId() + "_" + newSessionId();
             updateSessionCache = true;
 
             resp.addHeader("x-auth-token", "Session " + sessionKey);

--- a/src/main/java/io/rcktapp/api/handler/security/AuthHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/security/AuthHandler.java
@@ -48,7 +48,8 @@ import io.rcktapp.api.service.Service;
 
 public class AuthHandler implements Handler
 {
-   long                       sessionExp              = 1000 * 60 * 30; //30 minute default timeput
+   long                       sessionExp              = 1000 * 60 * 30; //30 minute default timeout
+   long                       sessionUpdate           = 1000 * 20;      //update a session every 10s to prevent spamming the cache with every request
    protected int              sessionMax              = 10000;
 
    protected int              failedMax               = 10;
@@ -211,7 +212,7 @@ public class AuthHandler implements Handler
          {
             if (now - user.getRequestAt() > sessionExp)
             {
-               sessionCache.remove(token);
+               sessionCache.remove(sessionKey);
                user = null;
             }
          }
@@ -222,13 +223,20 @@ public class AuthHandler implements Handler
 
       if (user != null)
       {
+         boolean updateSessionCache = false;
+         long previousReqTime = user.getRequestAt();
+         long diff = now - previousReqTime;
+         if (diff > sessionUpdate || (now == previousReqTime))
+            updateSessionCache = true;
+
          user.setRequestAt(now);
          req.setUser(user);
 
+         sessionKey = req.getApi().getId() + "_" + newSessionId();//
+
          if (sessionReq && req.isPost())
          {
-            sessionKey = req.getApi().getId() + "_" + newSessionId();//
-            sessionCache.put(sessionKey, user);
+            updateSessionCache = true;
 
             resp.addHeader("x-auth-token", "Session " + sessionKey);
             JSObject obj = new JSObject();
@@ -252,6 +260,9 @@ public class AuthHandler implements Handler
 
             resp.setJson(new JSObject("data", obj));
          }
+
+         if (updateSessionCache)
+            sessionCache.put(sessionKey, user);
       }
 
       if (req.getUser() != null)


### PR DESCRIPTION
Sessions currently timeout after 30m...no matter the amount of user activity that has taken place.  This fixes that by updating the session cache every x seconds.  By default, the x value is 10s.