### PR TITLE
im/2163/SupportForAlternateBaseProperties

### DIFF
--- a/src/main/java/io/rcktapp/api/service/Configurator.java
+++ b/src/main/java/io/rcktapp/api/service/Configurator.java
@@ -453,9 +453,13 @@ public class Configurator
    {
       Config config = new Config();
 
+      String environment = service.getEnvironment();
+
+      environment = environment == null ? "" : "-" + environment;
+
       for (int i = -1; i <= 100; i++)
       {
-         String fileName = service.getConfigPath() + "snooze" + (i < 0 ? "" : i) + ".properties";
+         String fileName = service.getConfigPath() + "snooze" + environment + (i < 0 ? "" : i) + ".properties";
          InputStream is = service.getResource(fileName);
          if (is != null)
          {
@@ -468,7 +472,7 @@ public class Configurator
       {
          for (int i = -1; i <= 100; i++)
          {
-            String fileName = service.getConfigPath() + "snooze" + (i < 0 ? "" : i) + "-" + service.getProfile() + ".properties";
+            String fileName = service.getConfigPath() + "snooze" + environment + (i < 0 ? "" : i) + "-" + service.getProfile() + ".properties";
             InputStream is = service.getResource(fileName);
             if (is != null)
             {

--- a/src/main/java/io/rcktapp/api/service/Configurator.java
+++ b/src/main/java/io/rcktapp/api/service/Configurator.java
@@ -455,7 +455,7 @@ public class Configurator
 
       String environment = service.getEnvironment();
 
-      environment = environment == null ? "" : "-" + environment;
+      environment = environment == null || environment.equalsIgnoreCase("") ? "" : "-" + environment;
 
       for (int i = -1; i <= 100; i++)
       {

--- a/src/main/java/io/rcktapp/api/service/Configurator.java
+++ b/src/main/java/io/rcktapp/api/service/Configurator.java
@@ -453,13 +453,13 @@ public class Configurator
    {
       Config config = new Config();
 
-      String environment = service.getEnvironment();
+      String appName = service.getAppName();
 
-      environment = environment == null || environment.equalsIgnoreCase("") ? "" : "-" + environment;
+      appName = appName == null || appName.equalsIgnoreCase("") ? "" : "-" + appName;
 
       for (int i = -1; i <= 100; i++)
       {
-         String fileName = service.getConfigPath() + "snooze" + environment + (i < 0 ? "" : i) + ".properties";
+         String fileName = service.getConfigPath() + "snooze" + appName + (i < 0 ? "" : i) + ".properties";
          InputStream is = service.getResource(fileName);
          if (is != null)
          {
@@ -472,7 +472,7 @@ public class Configurator
       {
          for (int i = -1; i <= 100; i++)
          {
-            String fileName = service.getConfigPath() + "snooze" + environment + (i < 0 ? "" : i) + "-" + service.getProfile() + ".properties";
+            String fileName = service.getConfigPath() + "snooze" + appName + (i < 0 ? "" : i) + "-" + service.getProfile() + ".properties";
             InputStream is = service.getResource(fileName);
             if (is != null)
             {

--- a/src/main/java/io/rcktapp/api/service/Service.java
+++ b/src/main/java/io/rcktapp/api/service/Service.java
@@ -62,6 +62,8 @@ public class Service
 
    protected String  profile        = null;
 
+   protected String  environment     = null;
+
    protected String  configPath     = "";
    protected int     configTimeout  = 10000;
    protected boolean configFast     = false;
@@ -796,6 +798,14 @@ public class Service
    public void setConfigTimeout(int configTimeout)
    {
       this.configTimeout = configTimeout;
+   }
+
+   public String getEnvironment() {
+      return environment;
+   }
+
+   public void setEnvironment(String environment) {
+      this.environment = environment;
    }
 
 }

--- a/src/main/java/io/rcktapp/api/service/Service.java
+++ b/src/main/java/io/rcktapp/api/service/Service.java
@@ -62,7 +62,7 @@ public class Service
 
    protected String  profile        = null;
 
-   protected String  environment     = null;
+   protected String  appName     = null;
 
    protected String  configPath     = "";
    protected int     configTimeout  = 10000;
@@ -800,12 +800,12 @@ public class Service
       this.configTimeout = configTimeout;
    }
 
-   public String getEnvironment() {
-      return environment;
+   public String getAppName() {
+      return appName;
    }
 
-   public void setEnvironment(String environment) {
-      this.environment = environment;
+   public void setAppName(String appName) {
+      this.appName = appName;
    }
 
 }


### PR DESCRIPTION
Added environment property to the Service class to be able to define what snooze-{environment}.properties and snooze-{environment}-{profile}.properties  file to use. If not environment is passed the default snooze.properties files will be used