### PR TITLE
Mc/3596/reports equals filter - [SPRINT 2021-06-21]

### DIFF
--- a/src/main/java/io/rcktapp/rql/sql/SqlRql.java
+++ b/src/main/java/io/rcktapp/rql/sql/SqlRql.java
@@ -285,7 +285,14 @@ public class SqlRql extends Rql
          }
          else
          {
-            sql.append(term1).append(" = ").append(term2);
+            if (caseInsensitive)
+            {
+               sql.append("LOWER(").append(term1).append(") = LOWER(").append(term2).append(")");
+            }
+            else
+            {
+               sql.append(term1).append(" = ").append(term2);
+            }
          }
       }
       else if ("w".equalsIgnoreCase(token) || "sw".equalsIgnoreCase(token) || "ew".equalsIgnoreCase(token))


### PR DESCRIPTION
https://circlek.atlassian.net/browse/NGRP-3596
### Details
- now checks for case insensitivity when converting rql to sql for equals
### Test Notes
- Create a new report
- Add 'Where X **equals** Y" to location filter 
- Add date and item filters
- Generate report
- Create a new report
- Add 'Where X **contains** Y" to location filter
- Add date and item filters
- Generate report
- Observe the two reports match
- Use a Y that filters for the same and nonzero amount of locations for both equals and contains
- Use filters that actually lead to reports with data (at least for contains)
- Repeat with Y with different case (lower/upper i.e GA vs ga)

**_Note_** because there is no difference for redshift between dev and prod we can use the **'Where Tags equals National'** location filter mentioned in the steps to reproduce in the ticket to generate a report even though it may not necessarily show any locations in the table on the details page.