### PR TITLE
s3 posts can be stored to a subpath given a specificed date format

### DIFF
--- a/src/main/java/io/rcktapp/api/handler/s3/S3DbRestHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/s3/S3DbRestHandler.java
@@ -17,6 +17,7 @@ package io.rcktapp.api.handler.s3;
 
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +84,7 @@ public class S3DbRestHandler implements Handler
    Logger       log     = LoggerFactory.getLogger(S3DbRestHandler.class);
 
    int          maxRows = 100;
+   String       s3DatePath = null;
 
    @Override
    public void service(Service service, Api api, Endpoint endpoint, Action action, Chain chain, Request req, Response res) throws Exception
@@ -302,6 +304,14 @@ public class S3DbRestHandler implements Handler
       S3Db db = (S3Db) table.getDb();
 
       S3Rql rql = (S3Rql) Rql.getRql(db.getType());
+
+      if (s3DatePath != null)
+      {
+         String datePath = new SimpleDateFormat(s3DatePath).format(new Date());
+         String newPath = req.getSubpath() + datePath;
+         req.setSubpath(newPath);
+      }
+
       S3Request s3Req = rql.buildS3Request(req, table, null);
 
       String key = s3Req.getKey();


### PR DESCRIPTION
Added the ability to apply  a date to the subpath when posting.  As an example, if you were to set `s3DatePath`  to `yyyy/MM/dd` and posted a file to `https://www.circleklift.com/api/us/s3/files` the file would be placed into the following bucket `files.circleklift.com/2021/08/29/someFilename`

I added this as I thought it might be useful for the files @elenamat will be accessing from PDI...if this is not helpful, or could be more helpful, please let me know