### PR TITLE
fixing escape error

### DIFF
--- a/src/main/java/io/rocketpartners/cloud/action/elastic/v03x/rql/Tokenizer.java
+++ b/src/main/java/io/rocketpartners/cloud/action/elastic/v03x/rql/Tokenizer.java
@@ -47,6 +47,7 @@ public class Tokenizer
                next.append(c);
                if (escape || doubleQuote || singleQuote)
                {
+                  escape = false;
                   continue;
                }
                done = true;
@@ -72,6 +73,7 @@ public class Tokenizer
                if (escape)
                {
                   next.append(c);
+                  escape = false;
                   continue;
                }
 
@@ -90,6 +92,7 @@ public class Tokenizer
                if (escape || singleQuote)
                {
                   next.append(c);
+                  escape = false;
                   continue;
                }
 


### PR DESCRIPTION
When we have elastic requests with filters like w(subcategoryName,'0702-ICED TEA \(READY-TO-DRINK\)') that have escaped parentheses, we need to set escape to false if escaped is true.
This is because if there's another special character that is not escaped (in this case the last single quote), we don't want it to be appended to next.
Ticket: https://circlek.atlassian.net/browse/NGRP-5157