### PR TITLE
im/4102/Consistent sorting of empty and null strings

### DIFF
--- a/src/main/java/io/rcktapp/rql/elastic/Order.java
+++ b/src/main/java/io/rcktapp/rql/elastic/Order.java
@@ -91,4 +91,36 @@ public class Order
       return list;
    }
 
+   /**
+    * @return the orderList with empty sorting
+    * [
+    *     {
+    *       "fieldName": {
+    *         "order": "asc",
+    *         "missing": "_last"
+    *       }
+    *     }, ...
+    *   ]
+    */
+
+   public List<Map<String, Map>> getOrderListWithEmptySorting()
+   {
+      List<Map<String, Map>> result = new ArrayList<>();
+      for (Map<String, String> sortEntry : getOrderList())
+      {
+         for (String property: sortEntry.keySet()) {
+            String order = sortEntry.get(property);
+
+            Map<String, String> newEntry = new HashMap();
+            newEntry.put("order", order);
+            newEntry.put("missing", "desc".equalsIgnoreCase(order) ? "_last": "_first");
+
+            Map<String, Map> newOrderEntry = new HashMap<>();
+            newOrderEntry.put(property, newEntry);
+
+            result.add(newOrderEntry);
+         }
+      }
+      return result;
+   }
 }

--- a/src/main/java/io/rcktapp/rql/elastic/QueryDsl.java
+++ b/src/main/java/io/rcktapp/rql/elastic/QueryDsl.java
@@ -101,7 +101,7 @@ public class QueryDsl extends ElasticQuery
 
       // Sorting - very basic 
       if (order != null)
-         dslMap.put("sort", order.getOrderList());
+         dslMap.put("sort", order.getOrderListWithEmptySorting());
 
       return dslMap;
    }


### PR DESCRIPTION
Ticket: https://circlek.atlassian.net/browse/NGRP-4102

This pr aims to solve an inconsistent sorting of empty and nulls strings. 
Right now, when sorting asc, empty string come first but null string always come last.
This change will sort first null strings along empty string when sorting asc
