### PR TITLE
hotfix content length in inversion 0.3

### DIFF
--- a/src/main/java/io/rcktapp/api/Response.java
+++ b/src/main/java/io/rcktapp/api/Response.java
@@ -244,4 +244,9 @@ public class Response
    {
       return in;
    }
+
+    public void withContentLength(int length)
+    {
+        addHeader("Content-Length", length + "");
+    }
 }

--- a/src/main/java/io/rcktapp/api/service/Service.java
+++ b/src/main/java/io/rcktapp/api/service/Service.java
@@ -282,6 +282,7 @@ public class Service
          res.debug(res.getStatusCode());
 
          String output = res.getText();
+         res.withContentLength(output.length());
          if (output != null)
          {
             if (res.getContentType() == null)


### PR DESCRIPTION
Add content length header to responses.  Stabilizes response times.