### PR TITLE
Liftbau 2803/replace sql calc found rows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## [0.3.6.4 - 09/23/24]
 - LIFTBAU-2613: fix long casting error
 
 ## [0.3.6.3 - 05/02/24]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- LIFTBAU-3803: Remove/replace SQL_CALC_FOUND_ROWS and FOUND_ROWS commands for performance
 
 ## [0.3.6.4 - 09/23/24]
 - LIFTBAU-2613: fix long casting error

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
    mavenCentral()
    // maven { url 'https://jitpack.io' }
-   maven { url "http://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release" }
+   maven { url "https://s3.amazonaws.com/redshift-maven-repository/release" }
 }
 
 dependencies {

--- a/src/main/java/io/rcktapp/api/handler/sql/SqlDb.java
+++ b/src/main/java/io/rcktapp/api/handler/sql/SqlDb.java
@@ -73,7 +73,7 @@ public class SqlDb extends Db
    protected int           poolMax                  = MAX_POOL_SIZE;
    protected int           idleConnectionTestPeriod = 3600; // in seconds
 
-   // set this to false to turn off SQL_CALC_FOUND_ROWS and SELECT FOUND_ROWS()
+   // set this to false to turn off row total calculation
    // Only impacts 'mysql' types
    protected boolean       calcRowsFound            = true;
 

--- a/src/main/java/io/rcktapp/api/handler/sql/SqlDeleteHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/sql/SqlDeleteHandler.java
@@ -29,7 +29,6 @@ import io.rcktapp.api.Api;
 import io.rcktapp.api.ApiException;
 import io.rcktapp.api.Chain;
 import io.rcktapp.api.Collection;
-import io.rcktapp.api.Db;
 import io.rcktapp.api.Endpoint;
 import io.rcktapp.api.Entity;
 import io.rcktapp.api.Request;
@@ -104,10 +103,6 @@ public class SqlDeleteHandler extends SqlHandler
                   throw new ApiException("Nested delete url: " + url + " failed!");
                }
             }
-
-            //         JSObject deletedKeyJs = new JSObject();
-            //         deletedKeyJs.put("deletedKeys", new JSArray(deletedKeys));
-            //         res.setJson(deletedKeyJs);
          }
          else
          {
@@ -195,8 +190,6 @@ public class SqlDeleteHandler extends SqlHandler
          Entity entity = collection.getEntity();
          String entityKey = req.getEntityKey();
 
-         //String table = rql.asCol(entity.getTable().getName());
-
          Map params = req.getParams();
          String keyAttr = collection.getEntity().getKey().getName();
          if (!J.empty(entityKey))
@@ -211,8 +204,6 @@ public class SqlDeleteHandler extends SqlHandler
          Stmt stmt = rql.createStmt(sql, entity.getTable(), params, replacer);
          stmt.setMaxRows(-1);
          sql = rql.toSql(stmt);
-
-         sql = sql.replaceAll("SQL_CALC_FOUND_ROWS", "");
 
          if (sql.toLowerCase().indexOf(" where ") < 0)
             throw new ApiException(SC.SC_400_BAD_REQUEST, "You can't delete from a table without a where clause or an individual ID.");

--- a/src/main/java/io/rcktapp/api/handler/sql/SqlGetHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/sql/SqlGetHandler.java
@@ -329,11 +329,13 @@ public class SqlGetHandler extends SqlHandler
       Rows rows = Sql.selectRows(conn, sql, vals);
       if (db.isCalcRowsFound() && chain.get("rowCount") == null)
       {
-         sql = sql.replaceFirst("\\*", "COUNT(*)");
+         sql = sql.substring(0, sql.indexOf("SELECT")+6) +
+                 " COUNT(*) " +
+                 sql.substring(sql.indexOf("FROM"));
 
-         int limitIndex = sql.indexOf("ORDER BY");
-         if(limitIndex > 0) {
-            sql = sql.substring(0, limitIndex);
+         int orderByIndex = sql.indexOf("ORDER BY");
+         if(orderByIndex > 0) {
+            sql = sql.substring(0, orderByIndex);
          }
 
          int found = Sql.selectInt(conn, sql, vals);

--- a/src/main/java/io/rcktapp/api/handler/sql/SqlGetHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/sql/SqlGetHandler.java
@@ -329,19 +329,14 @@ public class SqlGetHandler extends SqlHandler
       Rows rows = Sql.selectRows(conn, sql, vals);
       if (db.isCalcRowsFound() && chain.get("rowCount") == null)
       {
-         sql = "SELECT FOUND_ROWS()";
-         //TODO "SELECT FOUND_ROWS() is MySQL specific
-         //         if(!mysql)
-         //         {
-         //            sql = "SELECT count(*) " + sql.substring(sql.indexOf("FROM "), sql.length());
-         //            if (sql.indexOf("LIMIT ") > 0)
-         //               sql = sql.substring(0, sql.indexOf("LIMIT "));
-         //
-         //            if (sql.indexOf("ORDER BY ") > 0)
-         //               sql = sql.substring(0, sql.indexOf("ORDER BY "));   
-         //         }
+         sql = sql.replaceFirst("\\*", "COUNT(*)");
 
-         int found = Sql.selectInt(conn, sql);
+         int limitIndex = sql.indexOf("ORDER BY");
+         if(limitIndex > 0) {
+            sql = sql.substring(0, limitIndex);
+         }
+
+         int found = Sql.selectInt(conn, sql, vals);
 
          if (chain.isDebug())
          {
@@ -774,8 +769,6 @@ public class SqlGetHandler extends SqlHandler
 
    static boolean find(java.util.Collection<String> haystack, String needle)
    {
-      //      if(needle.equalsIgnoreCase("adcompleters.ad"))
-      //         System.out.println("asdf");
       String lc = needle.toLowerCase();
       if (haystack.contains(needle) || haystack.contains(lc))
          return true;

--- a/src/main/java/io/rcktapp/rql/sql/SqlRql.java
+++ b/src/main/java/io/rcktapp/rql/sql/SqlRql.java
@@ -100,12 +100,6 @@ public class SqlRql extends Rql
          stmt.parts.select = stmt.parts.select.substring(0, idx) + " DISTINCT " + stmt.parts.select.substring(idx, stmt.parts.select.length());
       }
 
-      if (isCalcRowsFound() && stmt.pagenum > 0 && stmt.parts.select.toLowerCase().trim().startsWith("select"))
-      {
-         int idx = stmt.parts.select.toLowerCase().indexOf("select") + 6;
-         stmt.parts.select = stmt.parts.select.substring(0, idx) + " SQL_CALC_FOUND_ROWS " + stmt.parts.select.substring(idx, stmt.parts.select.length());
-      }
-
       //--WHERE 
 
       if (stmt.where.size() > 0)

--- a/src/test/java/io/rcktapp/rql/TestSqlRql.java
+++ b/src/test/java/io/rcktapp/rql/TestSqlRql.java
@@ -72,13 +72,13 @@ public class TestSqlRql
                             "SELECT * FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name", //
                             "SELECT `country`, COUNT(`country`) AS 'result' FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name WHERE `status` IN('killed') GROUP BY `country` LIMIT 1", //
                             "SELECT `country`, COUNT(`country`) AS 'result' FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name WHERE `status` IN(?) GROUP BY `country` LIMIT 1", //
-                            "status", "'killed'"));//));            
+                            "status", "'killed'"));
 
       tests.add(new RqlTest("aggregate(count,country,result)&includes=country,result&in(status,killed)", //
                             "SELECT * FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name", //
                             "SELECT `country`, COUNT(`country`) AS 'result' FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name WHERE `status` IN('killed') GROUP BY `country`", //
                             "SELECT `country`, COUNT(`country`) AS 'result' FROM Person p JOIN Entry e ON p.id = e.personId JOIN Country c ON e.country = c.country_name WHERE `status` IN(?) GROUP BY `country`", //
-                            "status", "'killed'"));//));
+                            "status", "'killed'"));
 
       //Test 5
       tests.add(new RqlTest("aggregate(count,country,result)&includes=country,result&in(status,killed,other)", //
@@ -99,12 +99,12 @@ public class TestSqlRql
 
       tests.add(new RqlTest("pagenum=10&pagesize=20)", //
                             "select * from table1", //
-                            "select SQL_CALC_FOUND_ROWS * from table1 LIMIT 180, 20", //
+                            "select * from table1 LIMIT 180, 20", //
                             null));
 
       tests.add(new RqlTest("page(10,20)", //
                             "select * from table1", //
-                            "select SQL_CALC_FOUND_ROWS * from table1 LIMIT 180, 20", //
+                            "select * from table1 LIMIT 180, 20", //
                             null));
 
       //Test 10
@@ -338,17 +338,17 @@ public class TestSqlRql
       //45
       tests.add(new RqlTest("q=firstName=*w*", //
                             "select * from table1", //
-                            "select SQL_CALC_FOUND_ROWS * from table1 WHERE `firstName` LIKE '%w%'", //
-                            "select SQL_CALC_FOUND_ROWS * from table1 WHERE `firstName` LIKE ?", "firstName", "'%w%'"));
+                            "select * from table1 WHERE `firstName` LIKE '%w%'", //
+                            "select * from table1 WHERE `firstName` LIKE ?", "firstName", "'%w%'"));
 
       tests.add(new RqlTest("pagenum=1", //
                             "select * from table1", //
-                            "select SQL_CALC_FOUND_ROWS * from table1", //
+                            "select * from table1", //
                             null));
 
       tests.add(new RqlTest("as(if(captive, 'Taken Captive', 'Not Taken Captive'), 'Captive')", //
                             "select * from table1", //
-                            "select SQL_CALC_FOUND_ROWS *, IF(`captive`, 'Taken Captive', 'Not Taken Captive') AS 'Captive' from table1", //
+                            "select *, IF(`captive`, 'Taken Captive', 'Not Taken Captive') AS 'Captive' from table1", //
                             null));
 
       tests.add(new RqlTest("name='John Doe'", //
@@ -462,10 +462,8 @@ public class TestSqlRql
 
       if (!str1.equals(str2))
       {
-         str2 = str2.replaceAll("SQL_CALC_FOUND_ROWS ", "");
          str2 = str2.replaceAll(" LIMIT 0, 100", "");
 
-         str1 = str1.replaceAll("SQL_CALC_FOUND_ROWS ", "");
          str1 = str1.replaceAll(" LIMIT 0, 100", "");
 
          if (!str1.equals(str2))


### PR DESCRIPTION
Ticket: https://circlek.atlassian.net/browse/LIFTBAU-2803

Updating how we grab the total number of entries in a query to not use SQL_CALC_FOUND_ROWS and FOUND_ROWS(), since these commands have been deprecated & lead to extreme losses in performance in production workloads. For example, these commands cause the Alarms page in the portal to take 20 seconds to load, when it would take a fraction of a second to load otherwise. 

I might've put the base of this branch in a weird place on my local, leading to those first two commits from last year to be included below. Only pay attention to the commits with `LIFTBAU-2803`