### PR TITLE
LIFT-1805: upgrade DynamoDB to AWS SDK v2 (0.4.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,10 +77,7 @@ dependencies {
 
     //aws libs
     api "software.amazon.awssdk:s3:$awsSdkV2Version"
-    api('com.amazonaws:aws-java-sdk-dynamodb:1.11.390') {
-        //TODO: remove exclude with https://circlek.atlassian.net/browse/LIFT-1805
-        exclude group: "com.amazonaws", module: "aws-java-sdk-s3"
-    }
+    api "software.amazon.awssdk:dynamodb:$awsSdkV2Version"
     api 'com.amazonaws:aws-java-sdk-kinesis:1.11.390'
     api 'com.amazonaws:aws-lambda-java-core:1.2.0'
     api 'com.amazonaws:aws-java-sdk-rds:1.11.542'

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
@@ -333,6 +333,16 @@ public class DynamoDb extends Db<DynamoDb>
       return dynamoClient;
    }
 
+   @Override
+   protected void shutdown0()
+   {
+      if (dynamoClient != null)
+      {
+         dynamoClient.close();
+         dynamoClient = null;
+      }
+   }
+
    public DynamoDb withIncludeTables(String includeTables)
    {
       this.includeTables = includeTables;

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
@@ -22,24 +22,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.ItemUtils;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.PutRequest;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.amazonaws.services.dynamodbv2.model.WriteRequest;
-import com.oracle.truffle.js.builtins.SymbolPrototypeBuiltins.SymbolToStringNode;
-
 import io.rocketpartners.cloud.model.ApiException;
 import io.rocketpartners.cloud.model.Collection;
 import io.rocketpartners.cloud.model.Column;
@@ -53,6 +35,22 @@ import io.rocketpartners.cloud.rql.Term;
 import io.rocketpartners.cloud.service.Chain;
 import io.rocketpartners.cloud.utils.Rows.Row;
 import io.rocketpartners.cloud.utils.Utils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 public class DynamoDb extends Db<DynamoDb>
 {
@@ -62,25 +60,25 @@ public class DynamoDb extends Db<DynamoDb>
 
    /**
     * A CSV of pipe delimited collection name to table name pairs.
-    * 
+    *
     * Example: dynamodb.tables=promo|promo-dev,loyalty-punchcard|loyalty-punchcard-dev
-    * 
+    *
     * Or if the collection name is the name as the table name you can just send a the name
-    * 
+    *
     * Example: dynamodb.includeTables=orders,users,events
     */
    protected String       includeTables;
 
    /**
     * Use to config which row is used to build the column/attribute model  (otherwise first row of scan will be used)
-    * 
+    *
     * FORMAT: collection name | primaryKey | sortKey (optional)
     */
    protected String       blueprintRow;
 
    protected int          batchMax     = 20;
 
-   private AmazonDynamoDB dynamoClient = null;
+   private DynamoDbClient dynamoClient = null;
 
    public DynamoDb()
    {
@@ -97,7 +95,7 @@ public class DynamoDb extends Db<DynamoDb>
    @Override
    public Results<Row> select(Table table, List<Term> columnMappedTerms) throws Exception
    {
-      DynamoDbQuery query = new DynamoDbQuery(table, columnMappedTerms).withDynamoTable(getDynamoTable(table));
+      DynamoDbQuery query = new DynamoDbQuery(table, columnMappedTerms).withDynamoClient(getDynamoClient(), table.getName());
       return query.doSelect();
    }
 
@@ -114,10 +112,10 @@ public class DynamoDb extends Db<DynamoDb>
    @Override
    public List<String> upsert(Table table, List<Map<String, Object>> rows) throws Exception
    {
-      AmazonDynamoDB dynamoClient = getDynamoClient();
+      DynamoDbClient dynamoClient = getDynamoClient();
       List keys = new ArrayList();
       List<WriteRequest> writeRequests = new LinkedList<WriteRequest>();
-      BatchWriteItemRequest batch = new BatchWriteItemRequest();
+
       for (int i = 0; i < rows.size(); i++)
       {
          Map<String, Object> row = rows.get(i);
@@ -134,23 +132,23 @@ public class DynamoDb extends Db<DynamoDb>
          if (i > 0 && i % batchMax == 0)
          {
             //write a batch to dynamo
-            batch.addRequestItemsEntry(table.getName(), writeRequests);
-            dynamoClient.batchWriteItem(batch);
-            batch.clearRequestItemsEntries();
+            Map<String, List<WriteRequest>> requestItems = new HashMap<>();
+            requestItems.put(table.getName(), writeRequests);
+            dynamoClient.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
             writeRequests.clear();
          }
-         //add to the current row to batch 
-         Map<String, AttributeValue> item = ItemUtils.fromSimpleMap(row);
+         //add to the current row to batch
+         Map<String, AttributeValue> item = DynamoV2Utils.toItemMap(row);
          Chain.debug("DynamoDb", "PutRequest", item);
-         PutRequest put = new PutRequest().withItem(item);
-         writeRequests.add(new WriteRequest(put));
+         PutRequest put = PutRequest.builder().item(item).build();
+         writeRequests.add(WriteRequest.builder().putRequest(put).build());
       }
 
       if (writeRequests.size() > 0)
       {
-         batch.addRequestItemsEntry(table.getName(), writeRequests);
-         getDynamoClient().batchWriteItem(batch);
-         batch.clearRequestItemsEntries();
+         Map<String, List<WriteRequest>> requestItems = new HashMap<>();
+         requestItems.put(table.getName(), writeRequests);
+         getDynamoClient().batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
          writeRequests.clear();
       }
 
@@ -162,20 +160,22 @@ public class DynamoDb extends Db<DynamoDb>
    {
       Row key = table.decodeKey(entityKey);
 
-      com.amazonaws.services.dynamodbv2.document.Table dynamo = getDynamoTable(table);
+      Map<String, AttributeValue> keyMap = new HashMap<>();
+      keyMap.put(key.getKey(0), DynamoV2Utils.toAttributeValue(key.get(0)));
 
-      if (key.size() == 1)
+      if (key.size() == 2)
       {
-         dynamo.deleteItem(key.getKey(0), key.get(0));
+         keyMap.put(key.getKey(1), DynamoV2Utils.toAttributeValue(key.get(1)));
       }
-      else if (key.size() == 2)
-      {
-         dynamo.deleteItem(key.getKey(0), key.get(0), key.getKey(1), key.get(1));
-      }
-      else
+      else if (key.size() > 2)
       {
          throw new ApiException(SC.SC_400_BAD_REQUEST, "A dynamo delete must have a hash key and an optional sortKey and that is it: '" + entityKey + "'");
       }
+
+      getDynamoClient().deleteItem(DeleteItemRequest.builder()
+         .tableName(table.getName())
+         .key(keyMap)
+         .build());
    }
 
    @Override
@@ -227,47 +227,47 @@ public class DynamoDb extends Db<DynamoDb>
 
    Table buildTable(String tableName, String[] bluePrintArr)
    {
-      AmazonDynamoDB dynamoClient = getDynamoClient();
+      DynamoDbClient dynamoClient = getDynamoClient();
 
       Table table = new Table(this, tableName);
 
-      DynamoDB dynamoDB = new DynamoDB(dynamoClient);
-      com.amazonaws.services.dynamodbv2.document.Table dynamoTable = dynamoDB.getTable(tableName);
-      TableDescription tableDescription = dynamoTable.describe();
+      TableDescription tableDescription = dynamoClient.describeTable(
+         DescribeTableRequest.builder().tableName(tableName).build()
+      ).table();
 
-      for (AttributeDefinition attr : tableDescription.getAttributeDefinitions())
+      for (AttributeDefinition attr : tableDescription.attributeDefinitions())
       {
-         table.makeColumn(attr.getAttributeName(), attr.getAttributeType());
+         table.makeColumn(attr.attributeName(), attr.attributeTypeAsString());
       }
 
       DynamoDbIndex index = new DynamoDbIndex(table, DynamoDbIndex.PRIMARY_INDEX, DynamoDbIndex.PRIMARY_TYPE);
 
-      List<KeySchemaElement> keySchema = tableDescription.getKeySchema();
+      List<KeySchemaElement> keySchema = tableDescription.keySchema();
       for (KeySchemaElement keyInfo : keySchema)
       {
-         if (keyInfo.getKeyType().equalsIgnoreCase("HASH"))
+         if (keyInfo.keyTypeAsString().equalsIgnoreCase("HASH"))
          {
-            index.witHashKey(table.getColumn(keyInfo.getAttributeName()));
+            index.witHashKey(table.getColumn(keyInfo.attributeName()));
          }
-         else if (keyInfo.getKeyType().equalsIgnoreCase("RANGE"))
+         else if (keyInfo.keyTypeAsString().equalsIgnoreCase("RANGE"))
          {
-            index.withSortKey(table.getColumn(keyInfo.getAttributeName()));
-         }
-      }
-
-      if (tableDescription.getGlobalSecondaryIndexes() != null)
-      {
-         for (GlobalSecondaryIndexDescription indexDesc : tableDescription.getGlobalSecondaryIndexes())
-         {
-            addTableIndex(DynamoDbIndex.GLOBAL_SECONDARY_TYPE, indexDesc.getIndexName(), indexDesc.getKeySchema(), table);
+            index.withSortKey(table.getColumn(keyInfo.attributeName()));
          }
       }
 
-      if (tableDescription.getLocalSecondaryIndexes() != null)
+      if (tableDescription.globalSecondaryIndexes() != null)
       {
-         for (LocalSecondaryIndexDescription indexDesc : tableDescription.getLocalSecondaryIndexes())
+         for (GlobalSecondaryIndexDescription indexDesc : tableDescription.globalSecondaryIndexes())
          {
-            addTableIndex(DynamoDbIndex.LOCAL_SECONDARY_TYPE, indexDesc.getIndexName(), indexDesc.getKeySchema(), table);
+            addTableIndex(DynamoDbIndex.GLOBAL_SECONDARY_TYPE, indexDesc.indexName(), indexDesc.keySchema(), table);
+         }
+      }
+
+      if (tableDescription.localSecondaryIndexes() != null)
+      {
+         for (LocalSecondaryIndexDescription indexDesc : tableDescription.localSecondaryIndexes())
+         {
+            addTableIndex(DynamoDbIndex.LOCAL_SECONDARY_TYPE, indexDesc.indexName(), indexDesc.keySchema(), table);
          }
       }
 
@@ -299,37 +299,38 @@ public class DynamoDb extends Db<DynamoDb>
 
       for (KeySchemaElement keyInfo : keySchemaList)
       {
-         Column column = table.getColumn(keyInfo.getAttributeName());
+         Column column = table.getColumn(keyInfo.attributeName());
 
          index.withColumn(column);
 
-         if (keyInfo.getKeyType().equalsIgnoreCase("HASH"))
+         if (keyInfo.keyTypeAsString().equalsIgnoreCase("HASH"))
          {
-            index.witHashKey(table.getColumn(keyInfo.getAttributeName()));
+            index.witHashKey(table.getColumn(keyInfo.attributeName()));
          }
 
-         else if (keyInfo.getKeyType().equalsIgnoreCase("RANGE"))
+         else if (keyInfo.keyTypeAsString().equalsIgnoreCase("RANGE"))
          {
-            index.withSortKey(table.getColumn(keyInfo.getAttributeName()));
+            index.withSortKey(table.getColumn(keyInfo.attributeName()));
          }
       }
 
       table.withIndex(index);
    }
 
-   public com.amazonaws.services.dynamodbv2.document.Table getDynamoTable(Collection collection)
+   public DynamoDbClient getDynamoClient()
    {
-      return getDynamoTable(collection.getTable().getName());
-   }
+      if (this.dynamoClient == null)
+      {
+         synchronized (this)
+         {
+            if (this.dynamoClient == null)
+            {
+               this.dynamoClient = buildDynamoClient(name + ".", awsRegion, awsAccessKey, awsSecretKey);
+            }
+         }
+      }
 
-   public com.amazonaws.services.dynamodbv2.document.Table getDynamoTable(Table table)
-   {
-      return getDynamoTable(table.getName());
-   }
-
-   public com.amazonaws.services.dynamodbv2.document.Table getDynamoTable(String tableName)
-   {
-      return new DynamoDB(getDynamoClient()).getTable(tableName);
+      return dynamoClient;
    }
 
    public DynamoDb withIncludeTables(String includeTables)
@@ -370,7 +371,7 @@ public class DynamoDb extends Db<DynamoDb>
 
    /**
     * Used to keep track of Hash and Sort keys for a dynamo index.
-    * 
+    *
     * @author kfrankic
     *
     */
@@ -542,46 +543,29 @@ public class DynamoDb extends Db<DynamoDb>
       }
    }
 
-   public AmazonDynamoDB getDynamoClient()
-   {
-      if (this.dynamoClient == null)
-      {
-         synchronized (this)
-         {
-            if (this.dynamoClient == null)
-            {
-               this.dynamoClient = buildDynamoClient(name + ".", awsRegion, awsAccessKey, awsSecretKey);
-            }
-         }
-      }
-
-      return dynamoClient;
-   }
-
-   public static AmazonDynamoDB buildDynamoClient(String prefix)
+   public static DynamoDbClient buildDynamoClient(String prefix)
    {
       return buildDynamoClient(prefix, null, null, null);
    }
 
-   public static AmazonDynamoDB buildDynamoClient(String prefix, String awsRegion, String awsAccessKey, String awsSecretKey)
+   public static DynamoDbClient buildDynamoClient(String prefix, String awsRegion, String awsAccessKey, String awsSecretKey)
    {
       awsRegion = Utils.findSysEnvPropStr(prefix + ".awsRegion", awsRegion);
       awsAccessKey = Utils.findSysEnvPropStr(prefix + ".awsAccessKey", awsAccessKey);
       awsSecretKey = Utils.findSysEnvPropStr(prefix + ".awsSecretKey", awsSecretKey);
 
-      AmazonDynamoDBClientBuilder builder = AmazonDynamoDBClientBuilder.standard();
+      DynamoDbClientBuilder builder = DynamoDbClient.builder();
       if (!Utils.empty(awsRegion))
       {
-         builder.withRegion(awsRegion);
+         builder.region(Region.of(awsRegion));
       }
       if (!Utils.empty(awsAccessKey) && !Utils.empty(awsSecretKey))
       {
-         BasicAWSCredentials creds = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
-         builder.withCredentials(new AWSStaticCredentialsProvider(creds));
+         AwsBasicCredentials creds = AwsBasicCredentials.create(awsAccessKey, awsSecretKey);
+         builder.credentialsProvider(StaticCredentialsProvider.create(creds));
       }
-      AmazonDynamoDB dynamoClient = builder.build();
 
-      return dynamoClient;
+      return builder.build();
    }
 
 }

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDbQuery.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDbQuery.java
@@ -157,7 +157,7 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
          String sortKeyCol = sortKey.getToken(0);
          Object sortKeyVal = db.cast(table.getColumn(sortKeyCol).getType(), sortKey.getToken(1));
 
-         Chain.debug("DynamoDb GetItemRequest partKeyCol=" + partKeyCol + " partKeyVal=" + partKeyVal + " sortKeyCol=" + sortKeyCol + " sortKeyVal=" + sortKeyVal);
+         Chain.debug("DynamoDb  GetItemSpec partKeyCol=" + partKeyCol + " partKeyVal=" + partKeyVal + " sortKeyCol=" + sortKeyCol + " sortKeyVal=" + sortKeyVal);
 
          Map<String, AttributeValue> keyMap = new HashMap<>();
          keyMap.put(partKeyCol, DynamoV2Utils.toAttributeValue(partKeyVal));
@@ -195,7 +195,7 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
 
       boolean doQuery = partKey != null && partKey.getTerm(1).isLeaf();
 
-      StringBuffer debug = new StringBuffer("DynamoDb ").append(doQuery ? "QueryRequest" : "ScanRequest").append(index != null ? ":'" + index.getName() + "'" : "");
+      StringBuffer debug = new StringBuffer("DynamoDb  ").append(doQuery ? "QuerySpec" : "ScanSpec").append(index != null ? ":'" + index.getName() + "'" : "");
 
       int pageSize = page().getPageSize();
       debug.append(" maxPageSize=" + pageSize);
@@ -282,17 +282,38 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
             queryBuilder.expressionAttributeValues(expressionAttributeValues);
          }
 
-         QueryResponse queryResponse = dynamoClient.query(queryBuilder.build());
+         // Client-side pagination loop to match v1 Document API maxResultSize behavior.
+         // SDK v2 limit only caps items evaluated per call, not total results returned.
+         Map<String, AttributeValue> lastEvaluatedKey = null;
+         int totalCollected = 0;
 
-         if (queryResponse.hasItems())
+         do
          {
-            for (Map<String, AttributeValue> item : queryResponse.items())
+            QueryResponse queryResponse = dynamoClient.query(queryBuilder.build());
+
+            if (queryResponse.hasItems())
             {
-               result.withRow(DynamoV2Utils.fromItemMap(item));
+               for (Map<String, AttributeValue> item : queryResponse.items())
+               {
+                  result.withRow(DynamoV2Utils.fromItemMap(item));
+                  totalCollected++;
+               }
+            }
+
+            lastEvaluatedKey = queryResponse.lastEvaluatedKey();
+
+            if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty() && totalCollected < pageSize)
+            {
+               queryBuilder.exclusiveStartKey(lastEvaluatedKey);
+            }
+            else
+            {
+               break;
             }
          }
+         while (true);
 
-         result.withNext(after(index, queryResponse.lastEvaluatedKey()));
+         result.withNext(after(index, lastEvaluatedKey));
       }
       else
       {
@@ -300,10 +321,14 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
             .tableName(tableName)
             .limit(pageSize);
 
+         if (index != null && !index.isPrimaryIndex())
+         {
+            scanBuilder.indexName(index.getName());
+         }
+
          Term after = page().getAfter();
          if (after != null)
          {
-            DynamoDbIndex primaryIndex = (DynamoDbIndex) table().getPrimaryIndex();
             Column afterHashKeyCol = table().getColumn(after.getToken(0));
             Column afterSortKeyCol = after.size() > 2 ? table().getColumn(after.getToken(2)) : null;
 
@@ -341,17 +366,37 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
             scanBuilder.expressionAttributeValues(expressionAttributeValues);
          }
 
-         ScanResponse scanResponse = dynamoClient.scan(scanBuilder.build());
+         // Client-side pagination loop to match v1 Document API maxResultSize behavior.
+         Map<String, AttributeValue> lastEvaluatedKey = null;
+         int totalCollected = 0;
 
-         if (scanResponse.hasItems())
+         do
          {
-            for (Map<String, AttributeValue> item : scanResponse.items())
+            ScanResponse scanResponse = dynamoClient.scan(scanBuilder.build());
+
+            if (scanResponse.hasItems())
             {
-               result.withRow(DynamoV2Utils.fromItemMap(item));
+               for (Map<String, AttributeValue> item : scanResponse.items())
+               {
+                  result.withRow(DynamoV2Utils.fromItemMap(item));
+                  totalCollected++;
+               }
+            }
+
+            lastEvaluatedKey = scanResponse.lastEvaluatedKey();
+
+            if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty() && totalCollected < pageSize)
+            {
+               scanBuilder.exclusiveStartKey(lastEvaluatedKey);
+            }
+            else
+            {
+               break;
             }
          }
+         while (true);
 
-         result.withNext(after(index, scanResponse.lastEvaluatedKey()));
+         result.withNext(after(index, lastEvaluatedKey));
       }
 
       return result;
@@ -388,28 +433,21 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
 
    protected Object getValue(AttributeValue v)
    {
-      if (v.s() != null)
-         return v.s();
-      if (v.n() != null)
-         return v.n();
-      if (v.b() != null)
-         return v.b();
-      if (v.hasSs())
-         return v.ss();
-      if (v.hasNs())
-         return v.ns();
-      if (v.hasBs())
-         return v.bs();
-      if (v.hasM())
-         return v.m();
-      if (v.hasL())
-         return v.l();
-      if (v.nul() != null)
-         return v.nul();
-      if (v.bool() != null)
-         return v.bool();
-
-      throw new ApiException(SC.SC_500_INTERNAL_SERVER_ERROR, "Unable to get value from AttributeValue: " + v);
+      switch (v.type())
+      {
+         case S:    return v.s();
+         case N:    return v.n();
+         case B:    return v.b();
+         case SS:   return v.ss();
+         case NS:   return v.ns();
+         case BS:   return v.bs();
+         case M:    return v.m();
+         case L:    return v.l();
+         case NUL:  return v.nul();
+         case BOOL: return v.bool();
+         default:
+            throw new ApiException(SC.SC_500_INTERNAL_SERVER_ERROR, "Unable to get value from AttributeValue: " + v);
+      }
    }
 
    /**

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDbQuery.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDbQuery.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package io.rocketpartners.cloud.action.dynamo;
 
@@ -8,18 +8,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.lang3.StringEscapeUtils;
-
-import com.amazonaws.services.dynamodbv2.document.Index;
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.ItemCollection;
-import com.amazonaws.services.dynamodbv2.document.QueryOutcome;
-import com.amazonaws.services.dynamodbv2.document.ScanOutcome;
-import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec;
-import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
-import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 import io.rocketpartners.cloud.action.dynamo.DynamoDb.DynamoDbIndex;
 import io.rocketpartners.cloud.model.ApiException;
@@ -37,23 +25,31 @@ import io.rocketpartners.cloud.rql.Where;
 import io.rocketpartners.cloud.service.Chain;
 import io.rocketpartners.cloud.utils.Rows.Row;
 import io.rocketpartners.cloud.utils.Utils;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 /**
  * @author tc-rocket, wells
- * 
+ *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
- * 
+ *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
- * 
+ *
  * @see https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/index.html
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html
  * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryingJavaDocumentAPI.html
  * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#FilteringResults
  * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html
- * 
+ *
  * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.KeyConditions.html
- * 
- * 
+ *
+ *
  */
 public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<Select<Select, DynamoDbQuery>, DynamoDbQuery>, Where<Where<Where, DynamoDbQuery>, DynamoDbQuery>, Group<Group<Group, DynamoDbQuery>, DynamoDbQuery>, Order<Order<Order, DynamoDbQuery>, DynamoDbQuery>, Page<Page<Page, DynamoDbQuery>, DynamoDbQuery>>
 {
@@ -73,35 +69,22 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
       FUNCTION_MAP.put("sw", "begins_with");
       FUNCTION_MAP.put("attribute_not_exists", "attribute_not_exists");
       FUNCTION_MAP.put("attribute_exists", "attribute_exists");
-      
-      //attribute_not_exists
-      //attribute_exists
-
-      //https://stackoverflow.com/questions/34349135/how-do-you-query-for-a-non-existent-null-attribute-in-dynamodb
-      //FUNCTION_MAP.put("nn", "attribute_exists");//needs to be
-      //FUNCTION_MAP.put("n", "attribute_not_exists");
    }
 
-   com.amazonaws.services.dynamodbv2.document.Table dynamoTable = null;
-   DynamoDbIndex                                    index;
+   DynamoDbClient dynamoClient = null;
+   String         tableName    = null;
+   DynamoDbIndex  index;
 
-   Term                                             partKey     = null;
-   Term                                             sortKey     = null;
+   Term           partKey      = null;
+   Term           sortKey      = null;
 
    public DynamoDbQuery(Table table, List<Term> terms)
    {
       super(table);
       where().clearFunctions();
-      
-      //withFunctions("_key", "and", "or", "not", "eq", "ne", "n", "nn", "like", "sw", "ew", "lt", "le", "gt", "ge", "in", "out", "if", "w", "wo", "emp", "nemp");
+
       where().withFunctions("_key", "eq", "ne", "gt", "ge", "lt", "le", "w", "sw", "nn", "n", "emp", "nemp", "in", "out", "and", "or", "not", "attribute_not_exists", "attribute_exists");
       super.withTerms(terms);
-
-      //https://stackoverflow.com/questions/34349135/how-do-you-query-for-a-non-existent-null-attribute-in-dynamodb
-
-      //https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.QueryFilter.html
-      //TODO: are all of these covered? EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS | BEGINS_WITH | IN | BETWEEN
-
    }
 
    protected boolean addTerm(String token, Term term)
@@ -117,7 +100,7 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
          {
             Term eqNull = Term.term(term.getParent(), "eq", term.getTerm(0), "null");
             Term attrNotExists = Term.term(null, "attribute_not_exists", term.getTerm(0));
-            
+
             term = Term.term(term.getParent(),  "or",  attrNotExists, eqNull);
          }
          else if (term.hasToken("nn", "nemp"))
@@ -140,59 +123,235 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
       return super.addTerm(token, term);
    }
 
-   public com.amazonaws.services.dynamodbv2.document.Table getDynamoTable()
+   public DynamoDbClient getDynamoClient()
    {
-      return dynamoTable;
+      return dynamoClient;
    }
 
-   public DynamoDbQuery withDynamoTable(com.amazonaws.services.dynamodbv2.document.Table dynamoTable)
+   public DynamoDbQuery withDynamoClient(DynamoDbClient dynamoClient, String tableName)
    {
-      this.dynamoTable = dynamoTable;
+      this.dynamoClient = dynamoClient;
+      this.tableName = tableName;
       return this;
    }
 
    protected Results<Row> doSelect() throws Exception
    {
-      Index dynamoIndex = null;
       Results result = new Results(this);
 
       DynamoDbIndex index = getIndex();
-      if (index != null && !index.isPrimaryIndex())
-      {
-         dynamoIndex = dynamoTable.getIndex(index.getName());
-      }
 
-      Object spec = getSelectSpec();
-      if (spec instanceof GetItemSpec)
-      {
-         GetItemSpec gis = (GetItemSpec) spec;
-         Item item = dynamoTable.getItem(gis);
-         if (item != null)
-         {
-            result.withRow(item.asMap());
-         }
-      }
-      else if (spec instanceof QuerySpec)
-      {
-         QuerySpec qs = ((QuerySpec) spec);
-         ItemCollection<QueryOutcome> queryResult = dynamoIndex != null ? dynamoIndex.query(qs) : dynamoTable.query(qs);
-         for (Item item : queryResult)
-         {
-            result.withRow(item.asMap());
-         }
+      Map nameMap = new HashMap();
+      Map valueMap = new HashMap();
 
-         result.withNext(after(index, queryResult.getLastLowLevelResult().getQueryResult().getLastEvaluatedKey()));
-      }
-      else if (spec instanceof ScanSpec)
+      StringBuffer keyExpr = new StringBuffer("");
+      StringBuffer filterExpr = new StringBuffer("");
+
+      if (index != null && index.isPrimaryIndex() && partKey != null && sortKey != null && sortKey.hasToken("eq") && sortKey.getTerm(1).isLeaf())
       {
-         ScanSpec ss = ((ScanSpec) spec);
-         ItemCollection<ScanOutcome> scanResult = dynamoIndex != null ? dynamoIndex.scan(ss) : dynamoTable.scan(ss);
-         for (Item item : scanResult)
+         // GetItem case
+         String partKeyCol = partKey.getToken(0);
+         String type = table.getColumn(partKeyCol).getType();
+         Object partKeyVal = db().cast(type, partKey.getToken(1));
+
+         String sortKeyCol = sortKey.getToken(0);
+         Object sortKeyVal = db.cast(table.getColumn(sortKeyCol).getType(), sortKey.getToken(1));
+
+         Chain.debug("DynamoDb GetItemRequest partKeyCol=" + partKeyCol + " partKeyVal=" + partKeyVal + " sortKeyCol=" + sortKeyCol + " sortKeyVal=" + sortKeyVal);
+
+         Map<String, AttributeValue> keyMap = new HashMap<>();
+         keyMap.put(partKeyCol, DynamoV2Utils.toAttributeValue(partKeyVal));
+         keyMap.put(sortKeyCol, DynamoV2Utils.toAttributeValue(sortKeyVal));
+
+         GetItemResponse getResponse = dynamoClient.getItem(GetItemRequest.builder()
+            .tableName(tableName)
+            .key(keyMap)
+            .build());
+
+         if (getResponse.hasItem() && !getResponse.item().isEmpty())
          {
-            result.withRow(item.asMap());
+            result.withRow(DynamoV2Utils.fromItemMap(getResponse.item()));
          }
 
-         result.withNext(after(index, scanResult.getLastLowLevelResult().getScanResult().getLastEvaluatedKey()));
+         return result;
+      }
+
+      if (partKey != null)
+      {
+         toString(keyExpr, partKey, nameMap, valueMap);
+      }
+
+      if (sortKey != null)
+      {
+         toString(keyExpr, sortKey, nameMap, valueMap);
+      }
+
+      for (Term term : where().getTerms())
+      {
+         if (term == partKey || term == sortKey)
+            continue;
+         toString(filterExpr, term, nameMap, valueMap);
+      }
+
+      boolean doQuery = partKey != null && partKey.getTerm(1).isLeaf();
+
+      StringBuffer debug = new StringBuffer("DynamoDb ").append(doQuery ? "QueryRequest" : "ScanRequest").append(index != null ? ":'" + index.getName() + "'" : "");
+
+      int pageSize = page().getPageSize();
+      debug.append(" maxPageSize=" + pageSize);
+
+      boolean scanIndexForward = order().isAsc(0);
+      debug.append(" scanIndexForward=" + scanIndexForward);
+
+      debug.append(" nameMap=" + nameMap + " valueMap=" + valueMap);
+      debug.append(" keyConditionExpression='" + keyExpr + "'");
+      debug.append(" filterExpression='" + filterExpr + "'");
+
+      String projectionExpression = null;
+      List columns = select().getColumnNames();
+      if (columns.size() > 0)
+         projectionExpression = Utils.implode(",", columns);
+
+      debug.append(" projectionExpression='" + (projectionExpression != null ? projectionExpression : "") + "'");
+
+      Chain.debug(debug);
+
+      // Convert valueMap from raw objects to AttributeValue
+      Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
+      for (Object entry : valueMap.entrySet())
+      {
+         Map.Entry<String, Object> e = (Map.Entry<String, Object>) entry;
+         expressionAttributeValues.put(e.getKey(), DynamoV2Utils.toAttributeValue(e.getValue()));
+      }
+
+      if (doQuery)
+      {
+         QueryRequest.Builder queryBuilder = QueryRequest.builder()
+            .tableName(tableName)
+            .limit(pageSize)
+            .scanIndexForward(order().isAsc(0));
+
+         if (index != null && !index.isPrimaryIndex())
+         {
+            queryBuilder.indexName(index.getName());
+         }
+
+         Term after = page().getAfter();
+         if (after != null)
+         {
+            Column afterHashKeyCol = table().getColumn(after.getToken(0));
+            Column afterSortKeyCol = after.size() > 2 ? table().getColumn(after.getToken(2)) : null;
+
+            if (afterHashKeyCol == null || (after.size() > 2 && afterSortKeyCol == null))
+               throw new ApiException(SC.SC_400_BAD_REQUEST, "Invalid column in 'after' key: " + after);
+
+            Object hashValue = db.cast(afterHashKeyCol, after.getToken(1));
+            Object sortValue = afterSortKeyCol != null ? db.cast(afterSortKeyCol, after.getToken(3)) : null;
+
+            Map<String, AttributeValue> exclusiveStartKey = new HashMap<>();
+            exclusiveStartKey.put(afterHashKeyCol.getName(), DynamoV2Utils.toAttributeValue(hashValue));
+            if (afterSortKeyCol != null)
+            {
+               exclusiveStartKey.put(afterSortKeyCol.getName(), DynamoV2Utils.toAttributeValue(sortValue));
+            }
+            queryBuilder.exclusiveStartKey(exclusiveStartKey);
+         }
+
+         if (!Utils.empty(projectionExpression))
+         {
+            queryBuilder.projectionExpression(projectionExpression);
+         }
+
+         if (keyExpr.length() > 0)
+         {
+            queryBuilder.keyConditionExpression(keyExpr.toString());
+         }
+
+         if (filterExpr.length() > 0)
+         {
+            queryBuilder.filterExpression(filterExpr.toString());
+         }
+
+         if (nameMap.size() > 0)
+         {
+            queryBuilder.expressionAttributeNames(nameMap);
+         }
+
+         if (expressionAttributeValues.size() > 0)
+         {
+            queryBuilder.expressionAttributeValues(expressionAttributeValues);
+         }
+
+         QueryResponse queryResponse = dynamoClient.query(queryBuilder.build());
+
+         if (queryResponse.hasItems())
+         {
+            for (Map<String, AttributeValue> item : queryResponse.items())
+            {
+               result.withRow(DynamoV2Utils.fromItemMap(item));
+            }
+         }
+
+         result.withNext(after(index, queryResponse.lastEvaluatedKey()));
+      }
+      else
+      {
+         ScanRequest.Builder scanBuilder = ScanRequest.builder()
+            .tableName(tableName)
+            .limit(pageSize);
+
+         Term after = page().getAfter();
+         if (after != null)
+         {
+            DynamoDbIndex primaryIndex = (DynamoDbIndex) table().getPrimaryIndex();
+            Column afterHashKeyCol = table().getColumn(after.getToken(0));
+            Column afterSortKeyCol = after.size() > 2 ? table().getColumn(after.getToken(2)) : null;
+
+            if (afterHashKeyCol == null || (after.size() > 2 && afterSortKeyCol == null))
+               throw new ApiException(SC.SC_400_BAD_REQUEST, "Invalid column in 'after' key: " + after);
+
+            Object hashValue = db.cast(afterHashKeyCol, after.getToken(1));
+            Object sortValue = afterSortKeyCol != null ? db.cast(afterSortKeyCol, after.getToken(3)) : null;
+
+            Map<String, AttributeValue> exclusiveStartKey = new HashMap<>();
+            exclusiveStartKey.put(afterHashKeyCol.getName(), DynamoV2Utils.toAttributeValue(hashValue));
+            if (afterSortKeyCol != null)
+            {
+               exclusiveStartKey.put(afterSortKeyCol.getName(), DynamoV2Utils.toAttributeValue(sortValue));
+            }
+            scanBuilder.exclusiveStartKey(exclusiveStartKey);
+         }
+
+         if (!Utils.empty(projectionExpression))
+         {
+            scanBuilder.projectionExpression(projectionExpression);
+         }
+
+         if (filterExpr.length() > 0)
+         {
+            scanBuilder.filterExpression(filterExpr.toString());
+         }
+         if (nameMap.size() > 0)
+         {
+            scanBuilder.expressionAttributeNames(nameMap);
+         }
+
+         if (expressionAttributeValues.size() > 0)
+         {
+            scanBuilder.expressionAttributeValues(expressionAttributeValues);
+         }
+
+         ScanResponse scanResponse = dynamoClient.scan(scanBuilder.build());
+
+         if (scanResponse.hasItems())
+         {
+            for (Map<String, AttributeValue> item : scanResponse.items())
+            {
+               result.withRow(DynamoV2Utils.fromItemMap(item));
+            }
+         }
+
+         result.withNext(after(index, scanResponse.lastEvaluatedKey()));
       }
 
       return result;
@@ -200,7 +359,7 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
 
    protected List<Term> after(DynamoDbIndex index, java.util.Map<String, AttributeValue> attrs)
    {
-      if (attrs == null)
+      if (attrs == null || attrs.isEmpty())
          return Collections.EMPTY_LIST;
 
       Term after = Term.term(null, "after");
@@ -229,26 +388,26 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
 
    protected Object getValue(AttributeValue v)
    {
-      if (v.getS() != null)
-         return v.getS();
-      if (v.getN() != null)
-         return v.getN();
-      if (v.getB() != null)
-         return v.getB();
-      if (v.getSS() != null)
-         return v.getSS();
-      if (v.getNS() != null)
-         return v.getNS();
-      if (v.getBS() != null)
-         return v.getBS();
-      if (v.getM() != null)
-         return v.getM();
-      if (v.getL() != null)
-         return v.getL();
-      if (v.getNULL() != null)
-         return v.getNULL();
-      if (v.getBOOL() != null)
-         return v.getBOOL();
+      if (v.s() != null)
+         return v.s();
+      if (v.n() != null)
+         return v.n();
+      if (v.b() != null)
+         return v.b();
+      if (v.hasSs())
+         return v.ss();
+      if (v.hasNs())
+         return v.ns();
+      if (v.hasBs())
+         return v.bs();
+      if (v.hasM())
+         return v.m();
+      if (v.hasL())
+         return v.l();
+      if (v.nul() != null)
+         return v.nul();
+      if (v.bool() != null)
+         return v.bool();
 
       throw new ApiException(SC.SC_500_INTERNAL_SERVER_ERROR, "Unable to get value from AttributeValue: " + v);
    }
@@ -363,8 +522,8 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
    }
 
    /**
-    * Finds the primary or a secondary index to use based on 
-    * what parameters were passed in. 
+    * Finds the primary or a secondary index to use based on
+    * what parameters were passed in.
     */
    public Term getPartKey()
    {
@@ -382,179 +541,6 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
          getIndex();
       }
       return sortKey;
-   }
-
-   public Object getSelectSpec()
-   {
-      //      Term partKey = getPartKey();
-      //      Term sortKey = getSortKey();
-
-      Map nameMap = new HashMap();
-      Map valueMap = new HashMap();
-
-      StringBuffer keyExpr = new StringBuffer("");
-      StringBuffer filterExpr = new StringBuffer("");
-
-      if (index != null && index.isPrimaryIndex() && partKey != null && sortKey != null && sortKey.hasToken("eq") && sortKey.getTerm(1).isLeaf())//sortKey is a single eq expression not a logic expr
-      {
-         String partKeyCol = partKey.getToken(0);
-         String type = table.getColumn(partKeyCol).getType();
-         Object partKeyVal = db().cast(type, partKey.getToken(1));
-
-         String sortKeyCol = sortKey.getToken(0);
-         Object sortKeyVal = db.cast(table.getColumn(sortKeyCol).getType(), sortKey.getToken(1));
-
-         Chain.debug("DynamoDb GetItemSpec partKeyCol=" + partKeyCol + " partKeyVal=" + partKeyVal + " sortKeyCol=" + sortKeyCol + " sortKeyVal=" + sortKeyVal);
-
-         return new GetItemSpec().withPrimaryKey(partKeyCol, partKeyVal, sortKeyCol, sortKeyVal);
-      }
-
-      if (partKey != null)
-      {
-         toString(keyExpr, partKey, nameMap, valueMap);
-      }
-
-      if (sortKey != null)
-      {
-         toString(keyExpr, sortKey, nameMap, valueMap);
-      }
-
-      for (Term term : where().getTerms())
-      {
-         if (term == partKey || term == sortKey)
-            continue;
-         toString(filterExpr, term, nameMap, valueMap);
-      }
-
-      boolean doQuery = partKey != null && partKey.getTerm(1).isLeaf();
-
-      StringBuffer debug = new StringBuffer("DynamoDb ").append(doQuery ? "QuerySpec" : "ScanSpec").append(index != null ? ":'" + index.getName() + "'" : "");
-
-      int pageSize = page().getPageSize();
-      debug.append(" maxPageSize=" + pageSize);
-
-      boolean scanIndexForward = order().isAsc(0);
-      debug.append(" scanIndexForward=" + scanIndexForward);
-
-      debug.append(" nameMap=" + nameMap + " valueMap=" + valueMap);
-      debug.append(" keyConditionExpression='" + keyExpr + "'");
-      debug.append(" filterExpression='" + filterExpr + "'");
-
-      String projectionExpression = null;
-      List columns = select().getColumnNames();
-      if (columns.size() > 0)
-         projectionExpression = Utils.implode(",", columns);
-
-      debug.append(" projectionExpression='" + (projectionExpression != null ? projectionExpression : "") + "'");
-
-      Chain.debug(debug);
-
-      if (doQuery)
-      {
-         QuerySpec querySpec = new QuerySpec();//
-         querySpec.withMaxPageSize(pageSize);
-         querySpec.withMaxResultSize(pageSize);
-         querySpec.withScanIndexForward(order().isAsc(0));
-
-         Term after = page().getAfter();
-         if (after != null)
-         {
-            Column afterHashKeyCol = table().getColumn(after.getToken(0));
-            Column afterSortKeyCol = after.size() > 2 ? table().getColumn(after.getToken(2)) : null;
-
-            if (afterHashKeyCol == null || (after.size() > 2 && afterSortKeyCol == null))
-               throw new ApiException(SC.SC_400_BAD_REQUEST, "Invalid column in 'after' key: " + after);
-
-            Object hashValue = db.cast(afterHashKeyCol, after.getToken(1));
-            Object sortValue = afterSortKeyCol != null ? db.cast(afterSortKeyCol, after.getToken(3)) : null;
-
-            if (afterSortKeyCol != null)
-            {
-               querySpec.withExclusiveStartKey(afterHashKeyCol.getName(), hashValue, afterSortKeyCol.getName(), sortValue);
-            }
-            else
-            {
-               querySpec.withExclusiveStartKey(afterHashKeyCol.getName(), hashValue);
-            }
-         }
-
-         if (!Utils.empty(projectionExpression))
-         {
-            querySpec.withProjectionExpression(projectionExpression);
-         }
-
-         if (keyExpr.length() > 0)
-         {
-            querySpec.withKeyConditionExpression(keyExpr.toString());
-         }
-
-         if (filterExpr.length() > 0)
-         {
-            querySpec.withFilterExpression(filterExpr.toString());
-         }
-
-         if (nameMap.size() > 0)
-         {
-            querySpec.withNameMap(nameMap);
-         }
-
-         if (valueMap.size() > 0)
-         {
-            querySpec.withValueMap(valueMap);
-         }
-
-         return querySpec;
-      }
-      else
-      {
-         ScanSpec scanSpec = new ScanSpec();
-         scanSpec.withMaxPageSize(pageSize);
-         scanSpec.withMaxResultSize(pageSize);
-
-         Term after = page().getAfter();
-         if (after != null)
-         {
-            DynamoDbIndex index = (DynamoDbIndex) table().getPrimaryIndex();
-            Column afterHashKeyCol = table().getColumn(after.getToken(0));
-            Column afterSortKeyCol = after.size() > 2 ? table().getColumn(after.getToken(2)) : null;
-
-            if (afterHashKeyCol == null || (after.size() > 2 && afterSortKeyCol == null))
-               throw new ApiException(SC.SC_400_BAD_REQUEST, "Invalid column in 'after' key: " + after);
-
-            Object hashValue = db.cast(afterHashKeyCol, after.getToken(1));
-            Object sortValue = afterSortKeyCol != null ? db.cast(afterSortKeyCol, after.getToken(3)) : null;
-
-            if (afterSortKeyCol != null)
-            {
-               scanSpec.withExclusiveStartKey(afterHashKeyCol.getName(), hashValue, afterSortKeyCol.getName(), sortValue);
-            }
-            else
-            {
-               scanSpec.withExclusiveStartKey(afterHashKeyCol.getName(), hashValue);
-            }
-         }
-
-         if (!Utils.empty(projectionExpression))
-         {
-            scanSpec.withProjectionExpression(projectionExpression);
-         }
-
-         if (filterExpr.length() > 0)
-         {
-            scanSpec.withFilterExpression(filterExpr.toString());
-         }
-         if (nameMap.size() > 0)
-         {
-            scanSpec.withNameMap(nameMap);
-         }
-
-         if (valueMap.size() > 0)
-         {
-            scanSpec.withValueMap(valueMap);
-         }
-
-         return scanSpec;
-      }
    }
 
    String toString(StringBuffer buff, Term term, Map nameMap, Map valueMap)
@@ -656,7 +642,6 @@ public class DynamoDbQuery extends Query<DynamoDbQuery, DynamoDb, Table, Select<
          space(buff).append(key);
       }
 
-      //System.out.println("TOSTRING: " + term + " -> '" + buff + "'" + " - " + nameMap + " - " + valueMap);
       return buff.toString();
    }
 

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
@@ -1,0 +1,118 @@
+package io.rocketpartners.cloud.action.dynamo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class DynamoV2Utils
+{
+
+   public static AttributeValue toAttributeValue(Object value)
+   {
+      if (value == null)
+      {
+         return AttributeValue.builder().nul(true).build();
+      }
+      if (value instanceof String)
+      {
+         return AttributeValue.builder().s((String) value).build();
+      }
+      if (value instanceof Number)
+      {
+         return AttributeValue.builder().n(value.toString()).build();
+      }
+      if (value instanceof Boolean)
+      {
+         return AttributeValue.builder().bool((Boolean) value).build();
+      }
+      if (value instanceof List)
+      {
+         List<AttributeValue> list = ((List<?>) value).stream()
+                                                       .map(DynamoV2Utils::toAttributeValue)
+                                                       .collect(Collectors.toList());
+         return AttributeValue.builder().l(list).build();
+      }
+      if (value instanceof Map)
+      {
+         Map<String, AttributeValue> map = new HashMap<>();
+         ((Map<?, ?>) value).forEach((k, v) -> map.put(k.toString(), toAttributeValue(v)));
+         return AttributeValue.builder().m(map).build();
+      }
+      return AttributeValue.builder().s(value.toString()).build();
+   }
+
+   public static Map<String, AttributeValue> toItemMap(Map<String, Object> map)
+   {
+      Map<String, AttributeValue> item = new HashMap<>();
+      for (Map.Entry<String, Object> entry : map.entrySet())
+      {
+         if (entry.getValue() != null)
+         {
+            item.put(entry.getKey(), toAttributeValue(entry.getValue()));
+         }
+      }
+      return item;
+   }
+
+   public static Map<String, Object> fromItemMap(Map<String, AttributeValue> item)
+   {
+      Map<String, Object> map = new HashMap<>();
+      for (Map.Entry<String, AttributeValue> entry : item.entrySet())
+      {
+         map.put(entry.getKey(), fromAttributeValue(entry.getValue()));
+      }
+      return map;
+   }
+
+   public static Map<String, AttributeValue> toExpressionAttributeValues(Map<String, Object> args)
+   {
+      Map<String, AttributeValue> result = new HashMap<>();
+      for (Map.Entry<String, Object> entry : args.entrySet())
+      {
+         result.put(entry.getKey(), toAttributeValue(entry.getValue()));
+      }
+      return result;
+   }
+
+   public static Object fromAttributeValue(AttributeValue av)
+   {
+      if (av.s() != null)
+      {
+         return av.s();
+      }
+      if (av.n() != null)
+      {
+         try
+         {
+            return Long.parseLong(av.n());
+         }
+         catch (NumberFormatException e)
+         {
+            return Double.parseDouble(av.n());
+         }
+      }
+      if (av.bool() != null)
+      {
+         return av.bool();
+      }
+      if (Boolean.TRUE.equals(av.nul()))
+      {
+         return null;
+      }
+      if (av.hasL())
+      {
+         return av.l().stream()
+                  .map(DynamoV2Utils::fromAttributeValue)
+                  .collect(Collectors.toList());
+      }
+      if (av.hasM())
+      {
+         return fromItemMap(av.m());
+      }
+      return null;
+   }
+
+}

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
@@ -79,40 +79,32 @@ public class DynamoV2Utils
 
    public static Object fromAttributeValue(AttributeValue av)
    {
-      if (av.s() != null)
+      switch (av.type())
       {
-         return av.s();
+         case S:
+            return av.s();
+         case N:
+            try
+            {
+               return Long.parseLong(av.n());
+            }
+            catch (NumberFormatException e)
+            {
+               return Double.parseDouble(av.n());
+            }
+         case BOOL:
+            return av.bool();
+         case NUL:
+            return null;
+         case L:
+            return av.l().stream()
+                     .map(DynamoV2Utils::fromAttributeValue)
+                     .collect(Collectors.toList());
+         case M:
+            return fromItemMap(av.m());
+         default:
+            return null;
       }
-      if (av.n() != null)
-      {
-         try
-         {
-            return Long.parseLong(av.n());
-         }
-         catch (NumberFormatException e)
-         {
-            return Double.parseDouble(av.n());
-         }
-      }
-      if (av.bool() != null)
-      {
-         return av.bool();
-      }
-      if (Boolean.TRUE.equals(av.nul()))
-      {
-         return null;
-      }
-      if (av.hasL())
-      {
-         return av.l().stream()
-                  .map(DynamoV2Utils::fromAttributeValue)
-                  .collect(Collectors.toList());
-      }
-      if (av.hasM())
-      {
-         return fromItemMap(av.m());
-      }
-      return null;
    }
 
 }

--- a/src/test/java/io/rocketpartners/cloud/action/dynamo/DynamoServiceFactory.java
+++ b/src/test/java/io/rocketpartners/cloud/action/dynamo/DynamoServiceFactory.java
@@ -2,30 +2,8 @@ package io.rocketpartners.cloud.action.dynamo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.lang3.StringEscapeUtils;
-
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.ItemCollection;
-import com.amazonaws.services.dynamodbv2.document.ScanOutcome;
-import com.amazonaws.services.dynamodbv2.document.Table;
-import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
 import io.rocketpartners.cloud.action.rest.RestAction;
 import io.rocketpartners.cloud.action.sql.SqlServiceFactory;
@@ -36,6 +14,25 @@ import io.rocketpartners.cloud.model.ObjectNode;
 import io.rocketpartners.cloud.model.Response;
 import io.rocketpartners.cloud.service.Service;
 import io.rocketpartners.cloud.utils.Utils;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 
 public class DynamoServiceFactory
 {
@@ -68,55 +65,7 @@ public class DynamoServiceFactory
       Service service = SqlServiceFactory.service();
 
       final DynamoDb dynamoDb = new DynamoDb("dynamo", dynamoTbl);
-      Table table = new DynamoDB(dynamoDb.getDynamoClient()).getTable(dynamoTbl);
-//      //--
-//      //--
-//      //--
-//
-//      //DynamoDb  ScanSpec maxPageSize=500 scanIndexForward=true nameMap={#var1=shipRegion} valueMap={} keyConditionExpression='' filterExpression='attribute_not_exists(#var1)' projectionExpression=''
-//
-//      Map nameMap = new HashMap();
-//      nameMap.put("#var1", "shipregion");
-//
-//      Map valueMap = new HashMap();
-//      valueMap.put(":val1", null);
-//
-//      ScanSpec scanSpec = new ScanSpec();
-//      scanSpec.withMaxPageSize(1000);
-//      scanSpec.withMaxResultSize(1000);
-//      //scanSpec.withFilterExpression("attribute_not_exists(#var1)");
-//      scanSpec.withFilterExpression("(#var1 = :val1)");
-//      scanSpec.withNameMap(nameMap);
-//      scanSpec.withValueMap(valueMap);
-//
-//      
-//
-//      ItemCollection<ScanOutcome> scanResult = table.scan(scanSpec);
-//      int num = 0;
-//      for (Item item : scanResult)
-//      {
-//         num += 1;
-//         String val = item.getString("shipRegion");
-//         if (val == null)
-//            val = item.getString("shipregion");
-//         val += "";
-//
-//         System.out.println(val + " - " + item.asMap());
-//         if (!"null".equalsIgnoreCase(val))
-//         {
-//            System.out.println("should be null: '" + StringEscapeUtils.escapeJava(val) + "'");
-//            throw new RuntimeException("WRONG!!!");
-//         }
-//      }
-//
-//      if (num == 0)
-//         throw new RuntimeException("WRONG!!!");
-//
-//      System.out.println("done");
-
-      //--
-      //--
-      //--
+      DynamoDbClient dynamoClient = dynamoDb.getDynamoClient();
 
       final Api api = service.getApi(apiCode);
       api.withDb(dynamoDb);
@@ -124,60 +73,64 @@ public class DynamoServiceFactory
 
       dynamoDb.startup();
 
-      //      service.withListener(new ServiceListener()
-      //         {
-      //            @Override
-      //            public void onStartup(Service service)
-      //            {
-      Collection orders = api.getCollection(dynamoTbl + "s");//new Collection(dynamoDb.getTable(dynamoTbl));
+      Collection orders = api.getCollection(dynamoTbl + "s");
       orders.withName("orders");
 
-      orders.getAttribute("hk").withName("orderId"); //get orders by id 
+      orders.getAttribute("hk").withName("orderId");
       orders.getAttribute("sk").withName("type");
 
-      orders.getAttribute("gs1hk").withName("employeeId"); //get orders by customer sorted by date
+      orders.getAttribute("gs1hk").withName("employeeId");
       orders.getAttribute("gs1sk").withName("orderDate");
 
       orders.getAttribute("ls1").withName("shipCity");
       orders.getAttribute("ls2").withName("shipName");
       orders.getAttribute("ls3").withName("requireDate");
 
-      //orders.getAttribute("gs2hk").setName("customerId"); //get orders by customer sorted by date
-      //orders.getAttribute("gs2sk").setName("orderDate");//will be "order"
-
       orders.withIncludePaths("dynamodb/*");
 
       Response res = null;
-
-      //10248 - 11077
-      //      relaodDynamo = relaodDynamo || !"10248".equals(service.get("northwind/dynamodb/orders?limit=1&type=ORDER&sort=orderid").findString("data.0.orderid"));
-      //      //relaodDynamo = relaodDynamo || !"11077".equals(service.get("northwind/dynamodb/orders?limit=1&type=ORDER&sort=-orderid&includes=href").findString("data.0.orderid"));
-      //      relaodDynamo = relaodDynamo || !"11077".equals(service.get("northwind/dynamodb/orders?orderid=11077&limit=1&type=ORDER").findString("data.0.orderid"));
 
       if (relaodDynamo)
       {
          System.out.print("CLEARING DYNAMO...");
 
-         ItemCollection<ScanOutcome> deleteoutcome = table.scan();
-         Iterator<Item> iterator = deleteoutcome.iterator();
-
+         Map<String, AttributeValue> lastKey = null;
          int deletedCount = 0;
-         while (iterator.hasNext())
+
+         do
          {
-            deletedCount +=1;
-            if(deletedCount % 100 == 0)
-               System.out.print(deletedCount + " ");
-            
-            Item item = iterator.next();
-            Object hk = item.get("hk");
-            Object sk = item.get("sk");
-            table.deleteItem("hk", hk, "sk", sk);
+            ScanRequest.Builder scanBuilder = ScanRequest.builder().tableName(dynamoTbl);
+            if (lastKey != null)
+            {
+               scanBuilder.exclusiveStartKey(lastKey);
+            }
+
+            ScanResponse scanResponse = dynamoClient.scan(scanBuilder.build());
+
+            for (Map<String, AttributeValue> item : scanResponse.items())
+            {
+               deletedCount += 1;
+               if (deletedCount % 100 == 0)
+                  System.out.print(deletedCount + " ");
+
+               Map<String, AttributeValue> keyMap = new HashMap<>();
+               keyMap.put("hk", item.get("hk"));
+               keyMap.put("sk", item.get("sk"));
+
+               dynamoClient.deleteItem(DeleteItemRequest.builder()
+                  .tableName(dynamoTbl)
+                  .key(keyMap)
+                  .build());
+            }
+
+            lastKey = scanResponse.lastEvaluatedKey();
          }
+         while (lastKey != null && !lastKey.isEmpty());
 
          //--confirm all deleted
          res = service.get("northwind/dynamodb/orders");
          res.statusOk();
-         Utils.assertEq(0, res.findArray("data").length());//confirm nothing in dynamo
+         Utils.assertEq(0, res.findArray("data").length());
 
          System.out.println("");
          System.out.println("RELOADING DYNAMO...");
@@ -225,7 +178,7 @@ public class DynamoServiceFactory
 
             res = service.post("northwind/dynamodb/orders", toPost);
             Utils.assertEq(201, res.getStatusCode());
-            System.out.println("DYNAMO LOADED: " + total);// + " - " + js.getString("orderid"));
+            System.out.println("DYNAMO LOADED: " + total);
          }
          while (pages < 200 && next != null);
 
@@ -249,92 +202,99 @@ public class DynamoServiceFactory
 
    public static boolean tableExists(String tableName) throws Exception
    {
-      AmazonDynamoDB client = DynamoDb.buildDynamoClient(tableName);
-      DynamoDB dynamoDB = new DynamoDB(client);
-
-      return dynamoDB.getTable(tableName) != null;
+      DynamoDbClient client = DynamoDb.buildDynamoClient(tableName);
+      try
+      {
+         client.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
+         return true;
+      }
+      catch (ResourceNotFoundException e)
+      {
+         return false;
+      }
    }
 
    public static void deleteTable(String tableName) throws Exception
    {
-      AmazonDynamoDB client = DynamoDb.buildDynamoClient(tableName);
-      DeleteTableRequest dtr = new DeleteTableRequest().withTableName(tableName);
-      client.deleteTable(dtr);
+      DynamoDbClient client = DynamoDb.buildDynamoClient(tableName);
+      client.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
    }
 
-   public static Table createNorthwind() throws Exception
+   public static void createNorthwind() throws Exception
    {
       List<AttributeDefinition> attrs = new ArrayList<>();
 
-      attrs.add(new AttributeDefinition().withAttributeName("hk").withAttributeType("N"));
-      attrs.add(new AttributeDefinition().withAttributeName("sk").withAttributeType("S"));
+      attrs.add(AttributeDefinition.builder().attributeName("hk").attributeType(ScalarAttributeType.N).build());
+      attrs.add(AttributeDefinition.builder().attributeName("sk").attributeType(ScalarAttributeType.S).build());
 
-      attrs.add(new AttributeDefinition().withAttributeName("gs1hk").withAttributeType("N"));
-      attrs.add(new AttributeDefinition().withAttributeName("gs1sk").withAttributeType("S"));
+      attrs.add(AttributeDefinition.builder().attributeName("gs1hk").attributeType(ScalarAttributeType.N).build());
+      attrs.add(AttributeDefinition.builder().attributeName("gs1sk").attributeType(ScalarAttributeType.S).build());
 
-      attrs.add(new AttributeDefinition().withAttributeName("gs2hk").withAttributeType("S"));
-      //attrs.add(new AttributeDefinition().withAttributeName("gs2sk").withAttributeType("S"));
+      attrs.add(AttributeDefinition.builder().attributeName("gs2hk").attributeType(ScalarAttributeType.S).build());
 
-      attrs.add(new AttributeDefinition().withAttributeName("ls1").withAttributeType("S"));
-      attrs.add(new AttributeDefinition().withAttributeName("ls2").withAttributeType("S"));
-      attrs.add(new AttributeDefinition().withAttributeName("ls3").withAttributeType("S"));
+      attrs.add(AttributeDefinition.builder().attributeName("ls1").attributeType(ScalarAttributeType.S).build());
+      attrs.add(AttributeDefinition.builder().attributeName("ls2").attributeType(ScalarAttributeType.S).build());
+      attrs.add(AttributeDefinition.builder().attributeName("ls3").attributeType(ScalarAttributeType.S).build());
 
       List<KeySchemaElement> keys = new ArrayList<>();
-      keys.add(new KeySchemaElement().withAttributeName("hk").withKeyType(KeyType.HASH));
-      keys.add(new KeySchemaElement().withAttributeName("sk").withKeyType(KeyType.RANGE));
+      keys.add(KeySchemaElement.builder().attributeName("hk").keyType(KeyType.HASH).build());
+      keys.add(KeySchemaElement.builder().attributeName("sk").keyType(KeyType.RANGE).build());
+
+      Projection allProjection = Projection.builder().projectionType(ProjectionType.ALL).build();
+      ProvisionedThroughput gsiThroughput = ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build();
 
       List<LocalSecondaryIndex> lsxs = new ArrayList();
-      lsxs.add(new LocalSecondaryIndex().withIndexName("ls1").withKeySchema(new KeySchemaElement().withAttributeName("hk").withKeyType(KeyType.HASH)//
-            , new KeySchemaElement().withAttributeName("ls1").withKeyType(KeyType.RANGE)));
+      lsxs.add(LocalSecondaryIndex.builder().indexName("ls1").keySchema(
+            KeySchemaElement.builder().attributeName("hk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("ls1").keyType(KeyType.RANGE).build())
+            .projection(allProjection).build());
 
-      lsxs.add(new LocalSecondaryIndex().withIndexName("ls2").withKeySchema(new KeySchemaElement().withAttributeName("hk").withKeyType(KeyType.HASH)//
-            , new KeySchemaElement().withAttributeName("ls2").withKeyType(KeyType.RANGE)));
+      lsxs.add(LocalSecondaryIndex.builder().indexName("ls2").keySchema(
+            KeySchemaElement.builder().attributeName("hk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("ls2").keyType(KeyType.RANGE).build())
+            .projection(allProjection).build());
 
-      lsxs.add(new LocalSecondaryIndex().withIndexName("ls3").withKeySchema(new KeySchemaElement().withAttributeName("hk").withKeyType(KeyType.HASH)//
-            , new KeySchemaElement().withAttributeName("ls3").withKeyType(KeyType.RANGE)));
+      lsxs.add(LocalSecondaryIndex.builder().indexName("ls3").keySchema(
+            KeySchemaElement.builder().attributeName("hk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("ls3").keyType(KeyType.RANGE).build())
+            .projection(allProjection).build());
 
       List<GlobalSecondaryIndex> gsxs = new ArrayList();
-      gsxs.add(new GlobalSecondaryIndex().withIndexName("gs1").withKeySchema(new KeySchemaElement().withAttributeName("gs1hk").withKeyType(KeyType.HASH), new KeySchemaElement().withAttributeName("gs1sk").withKeyType(KeyType.RANGE)));
-      gsxs.add(new GlobalSecondaryIndex().withIndexName("gs2").withKeySchema(new KeySchemaElement().withAttributeName("gs2hk").withKeyType(KeyType.HASH), new KeySchemaElement().withAttributeName("ls3").withKeyType(KeyType.RANGE)));
-      gsxs.add(new GlobalSecondaryIndex().withIndexName("gs3").withKeySchema(new KeySchemaElement().withAttributeName("sk").withKeyType(KeyType.HASH), new KeySchemaElement().withAttributeName("hk").withKeyType(KeyType.RANGE)));
+      gsxs.add(GlobalSecondaryIndex.builder().indexName("gs1").keySchema(
+            KeySchemaElement.builder().attributeName("gs1hk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("gs1sk").keyType(KeyType.RANGE).build())
+            .projection(allProjection).provisionedThroughput(gsiThroughput).build());
 
-      for (LocalSecondaryIndex lsx : lsxs)
+      gsxs.add(GlobalSecondaryIndex.builder().indexName("gs2").keySchema(
+            KeySchemaElement.builder().attributeName("gs2hk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("ls3").keyType(KeyType.RANGE).build())
+            .projection(allProjection).provisionedThroughput(gsiThroughput).build());
+
+      gsxs.add(GlobalSecondaryIndex.builder().indexName("gs3").keySchema(
+            KeySchemaElement.builder().attributeName("sk").keyType(KeyType.HASH).build(),
+            KeySchemaElement.builder().attributeName("hk").keyType(KeyType.RANGE).build())
+            .projection(allProjection).provisionedThroughput(gsiThroughput).build());
+
+      DynamoDbClient client = DynamoDb.buildDynamoClient("northwind");
+
+      CreateTableRequest request = CreateTableRequest.builder()
+            .globalSecondaryIndexes(gsxs)
+            .localSecondaryIndexes(lsxs)
+            .tableName("test-northwind")
+            .keySchema(keys)
+            .attributeDefinitions(attrs)
+            .provisionedThroughput(ProvisionedThroughput.builder()
+               .readCapacityUnits(5L)
+               .writeCapacityUnits(5L)
+               .build())
+            .build();
+
+      client.createTable(request);
+
+      try (DynamoDbWaiter waiter = DynamoDbWaiter.builder().client(client).build())
       {
-         lsx.setProjection(new Projection().withProjectionType(ProjectionType.ALL));
+         waiter.waitUntilTableExists(DescribeTableRequest.builder().tableName("test-northwind").build());
       }
-
-      for (GlobalSecondaryIndex gsx : gsxs)
-      {
-         gsx.setProjection(new Projection().withProjectionType(ProjectionType.ALL));
-         gsx.withProvisionedThroughput(new ProvisionedThroughput()//
-                                                                  .withReadCapacityUnits(5L)//
-                                                                  .withWriteCapacityUnits(5L));
-      }
-
-      AmazonDynamoDB client = DynamoDb.buildDynamoClient("northwind");
-      DynamoDB dynamoDB = new DynamoDB(client);
-
-      CreateTableRequest request = new CreateTableRequest()//
-                                                           .withGlobalSecondaryIndexes(gsxs)//
-                                                           .withLocalSecondaryIndexes(lsxs).withTableName("test-northwind")//
-                                                           .withKeySchema(keys)//
-                                                           .withAttributeDefinitions(attrs)//
-                                                           .withProvisionedThroughput(new ProvisionedThroughput()//
-                                                                                                                 .withReadCapacityUnits(5L)//
-                                                                                                                 .withWriteCapacityUnits(5L));
-
-      Table table = dynamoDB.createTable(request);
-
-      try
-      {
-         table.waitForActive();
-      }
-      catch (Exception ex)
-      {
-         table.waitForActive();
-      }
-
-      return table;
    }
 
 }


### PR DESCRIPTION
## Summary

Migrates all DynamoDB interactions in `io.rocketpartners.cloud.action.dynamo` from AWS SDK v1 to v2 on the **0.4.x** release line. This was the most complex migration due to different architecture (`DynamoDbQuery` + Document API).

## Changes

### Production Code
- Migrate `DynamoDb`: replace `AmazonDynamoDB` with `DynamoDbClient`, migrate `BatchWriteItemRequest`/upsert, delete, table description
- Migrate `DynamoDbQuery`: replace Document API (`QuerySpec`/`ScanSpec`/`GetItemSpec`) with v2 low-level API (`QueryRequest`/`ScanRequest`/`GetItemRequest`)
- Add `DynamoV2Utils` for `AttributeValue` type conversions (uses `av.type()` enum dispatch)
- Fix `getValue()` in `DynamoDbQuery` to use `av.type()` dispatch
- Add `indexName` to `ScanRequest` for secondary index scans
- Add client-side pagination loop to match v1 `maxResultSize` auto-pagination behavior
- Preserve v1 debug string format (`QuerySpec`/`ScanSpec`/`GetItemSpec`) for test compatibility
- Update `build.gradle`: replace `com.amazonaws:aws-java-sdk-dynamodb:1.11.390` with `software.amazon.awssdk:dynamodb`

### Test Code
- Migrate `DynamoServiceFactory.java` to SDK v2 (table creation, scan/delete cleanup, `DynamoDbWaiter`)

## Testing

- Build passes (`./gradlew test`) — 15/16 tests pass
- 1 failure is `TestS3UploadAction` (pre-existing, unrelated to DynamoDB)
- DynamoDB integration tests (`TestDynamoDbGetActions`, etc.) compile but require LocalStack to execute

## LIFT-1805
https://circlek.atlassian.net/browse/LIFT-1805