### PR TITLE
LIFT-1805: fix number precision, thread safety, and missing type hand…

### DIFF
--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoDb.java
@@ -78,7 +78,7 @@ public class DynamoDb extends Db<DynamoDb>
 
    protected int          batchMax     = 20;
 
-   private DynamoDbClient dynamoClient = null;
+   private volatile DynamoDbClient dynamoClient = null;
 
    public DynamoDb()
    {

--- a/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
+++ b/src/main/java/io/rocketpartners/cloud/action/dynamo/DynamoV2Utils.java
@@ -84,14 +84,7 @@ public class DynamoV2Utils
          case S:
             return av.s();
          case N:
-            try
-            {
-               return Long.parseLong(av.n());
-            }
-            catch (NumberFormatException e)
-            {
-               return Double.parseDouble(av.n());
-            }
+            return new java.math.BigDecimal(av.n());
          case BOOL:
             return av.bool();
          case NUL:
@@ -102,6 +95,16 @@ public class DynamoV2Utils
                      .collect(Collectors.toList());
          case M:
             return fromItemMap(av.m());
+         case SS:
+            return new java.util.ArrayList<>(av.ss());
+         case NS:
+            return av.ns().stream()
+                     .map(n -> (Object) new java.math.BigDecimal(n))
+                     .collect(Collectors.toList());
+         case BS:
+            return new java.util.ArrayList<>(av.bs());
+         case B:
+            return av.b();
          default:
             return null;
       }


### PR DESCRIPTION
…ling (0.4.x)

- Use BigDecimal for DynamoDB N/NS types to match v1 SDK behavior
- Add volatile to dynamoClient field for double-checked locking
- Add SS/NS/BS/B handling in fromAttributeValue