### PR TITLE
LIFT-1805: DynamoDB SDK v2 migration (0.4.x)

### DIFF
--- a/src/main/java/io/rocketpartners/cloud/action/s3/S3UploadAction.java
+++ b/src/main/java/io/rocketpartners/cloud/action/s3/S3UploadAction.java
@@ -98,11 +98,11 @@ public class S3UploadAction extends Action<S3UploadAction>
          {
             Upload upload = uploads.get(0);
             contentLength = upload.getFileSize();
+            fileSize = contentLength;
 
             uploadStream = new DigestInputStream(upload.getInputStream(), MessageDigest.getInstance("MD5"));
             String[] fileNameParts = upload.getFileName().split("[.]");
             fileName = "" + fileNameParts[0] + "-" + System.currentTimeMillis() + "." + fileNameParts[1];
-            fileSize = upload.getFileSize();
 
             requestPath = upload.getRequestPath();
             if (requestPath.indexOf("/") == 0)


### PR DESCRIPTION
## Summary
- Upgrades DynamoDB from AWS SDK v1 to v2
- Fixes redundant `getFileSize()` call in `S3UploadAction` introduced during S3 SDK v2 migration (causes test failure)

## Test plan
- [ ] All unit tests pass (`./gradlew test`)
- [ ] DynamoDB operations verified against dev environment