### PR TITLE
LIFT-1807: upgrade RDS to AWS SDK v2 (0.4.x)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [0.4.7 - 03/30/26]
+- LIFT-1807: Upgrade RDS IAM auth token generation to AWS SDK v2
+
 ## [0.4.6 - 03/17/26]
 - LIFT-1805: AWS DynamoDB SDK V2 upgrade
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ project.docsDirName = '../docs/0.3.x/'
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
 
-version = '0.4.7'
+version = '0.4.8'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ project.docsDirName = '../docs/0.3.x/'
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
 
-version = '0.4.6'
+version = '0.4.7'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 
@@ -80,7 +80,7 @@ dependencies {
     api "software.amazon.awssdk:dynamodb:$awsSdkV2Version"
     api 'com.amazonaws:aws-java-sdk-kinesis:1.11.390'
     api 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    api 'com.amazonaws:aws-java-sdk-rds:1.11.542'
+    api "software.amazon.awssdk:rds:$awsSdkV2Version"
 
     // required for the Redis client
     api group: 'redis.clients', name: 'jedis', version: '5.2.0'

--- a/src/main/java/io/rocketpartners/cloud/action/sql/RdsIamDataSource.java
+++ b/src/main/java/io/rocketpartners/cloud/action/sql/RdsIamDataSource.java
@@ -1,11 +1,12 @@
 package io.rocketpartners.cloud.action.sql;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
-import com.amazonaws.services.rds.auth.GetIamAuthTokenRequest;
-import com.amazonaws.services.rds.auth.RdsIamAuthTokenGenerator;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest;
 
 public class RdsIamDataSource extends HikariDataSource {
 
@@ -19,15 +20,16 @@ public class RdsIamDataSource extends HikariDataSource {
     }
 
     private String generateAuthToken() {
-        RdsIamAuthTokenGenerator generator = RdsIamAuthTokenGenerator.builder()
-                .credentials(new DefaultAWSCredentialsProviderChain())
-                .region(new DefaultAwsRegionProviderChain().getRegion())
+        Region region = new DefaultAwsRegionProviderChain().getRegion();
+        RdsUtilities utilities = RdsUtilities.builder()
+                .region(region)
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
 
-        return generator.getAuthToken(GetIamAuthTokenRequest.builder()
+        return utilities.generateAuthenticationToken(GenerateAuthenticationTokenRequest.builder()
                 .hostname(determineHostname(getJdbcUrl()))
                 .port(determinePort(getJdbcUrl()))
-                .userName(getUsername())
+                .username(getUsername())
                 .build());
     }
 

--- a/src/main/java/io/rocketpartners/cloud/action/sql/SqlDb.java
+++ b/src/main/java/io/rocketpartners/cloud/action/sql/SqlDb.java
@@ -16,10 +16,6 @@
 package io.rocketpartners.cloud.action.sql;
 
 import ch.qos.logback.classic.Level;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
-import com.amazonaws.services.rds.auth.GetIamAuthTokenRequest;
-import com.amazonaws.services.rds.auth.RdsIamAuthTokenGenerator;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.rocketpartners.cloud.model.ApiException;


### PR DESCRIPTION
## Summary
- Replaces `com.amazonaws:aws-java-sdk-rds:1.11.542` (v1) with `software.amazon.awssdk:rds:2.41.34` (v2) in `build.gradle`
- Migrates `RdsIamDataSource.generateAuthToken()` from `RdsIamAuthTokenGenerator`/`GetIamAuthTokenRequest` to `RdsUtilities`/`GenerateAuthenticationTokenRequest`
- Removes unused v1 RDS dead imports from `SqlDb.java`
- Part of the platform-wide AWS SDK v1 → v2 migration (follows LIFT-1805 DynamoDB, LIFT-1804 S3)

## Test plan
- [x] `./gradlew build` passes — no compilation errors
- [x] `./gradlew test` passes — `RdsIamDataSourceTest`

Jira: https://circlek.atlassian.net/browse/LIFT-1807