### PR TITLE
LIFT-1806: Upgrade Firehose to AWS SDK v2 (0.3.6.x)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [0.3.6.16 - 03/30/26]
+- LIFT-1806: Upgrade Firehose to AWS SDK v2
+
 ## [0.3.6.14 - 03/20/26]
 - LIFT-1805: Upgrade DynamoDB from AWS SDK v1 to v2
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.14'
+version = '0.3.6.15'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 
@@ -86,7 +86,7 @@ dependencies {
 
    api "software.amazon.awssdk:s3:$awsSdkV2Version"
    api "software.amazon.awssdk:dynamodb:$awsSdkV2Version"
-   api 'com.amazonaws:aws-java-sdk-kinesis:1.11.390'
+   api "software.amazon.awssdk:firehose:$awsSdkV2Version"
    api 'com.amazonaws:aws-java-sdk-rds:1.11.542'
 
    // Beware of changing the redshift driver version. Newer versions of this driver are not thread-safe

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.15'
+version = '0.3.6.16'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
@@ -1,12 +1,12 @@
 package io.rcktapp.api.handler.firehose;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsyncClientBuilder;
 import org.atteo.evo.inflector.English;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.FirehoseClientBuilder;
 
 import io.forty11.j.J;
 import io.rcktapp.api.Collection;
@@ -16,27 +16,27 @@ import io.rcktapp.api.Table;
 
 public class FirehoseDb extends Db
 {
-   protected String      awsAccessKey   = null;
-   protected String      awsSecretKey   = null;
-   protected String      awsRegion      = null;
+   protected String awsAccessKey = null;
+   protected String awsSecretKey = null;
+   protected String awsRegion    = null;
 
    /**
     * A CSV of pipe delimited collection name to table name pairs.
-    * 
+    *
     * Example: firehosedb.includeStreams=impression|liftck-player9-impression
-    * 
+    *
     * Or if the collection name is the name as the table name you can just send a the name
-    * 
+    *
     * Example: firehosedb.includeStreams=liftck-player9-impression
     */
-   protected String      includeStreams;
+   protected String includeStreams;
 
-   AmazonKinesisFirehoseAsync firehoseClient = null;
+   FirehoseClient firehoseClient = null;
 
    @Override
    public void bootstrapApi() throws Exception
    {
-      AmazonKinesisFirehose firehoseClient = getFirehoseClient();
+      FirehoseClient firehoseClient = getFirehoseClient();
 
       this.setType("firehose");
 
@@ -78,7 +78,7 @@ public class FirehoseDb extends Db
       }
    }
 
-   public AmazonKinesisFirehoseAsync getFirehoseClient()
+   public FirehoseClient getFirehoseClient()
    {
       if (this.firehoseClient == null)
       {
@@ -86,14 +86,14 @@ public class FirehoseDb extends Db
          {
             if (this.firehoseClient == null)
             {
-               AmazonKinesisFirehoseAsyncClientBuilder builder = AmazonKinesisFirehoseAsyncClientBuilder.standard();
+               FirehoseClientBuilder builder = FirehoseClient.builder();
                if (!J.empty(awsRegion))
-                  builder.withRegion(awsRegion);
+                  builder.region(Region.of(awsRegion));
 
                if (!J.empty(awsAccessKey) && !J.empty(awsSecretKey))
                {
-                  BasicAWSCredentials creds = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
-                  builder.withCredentials(new AWSStaticCredentialsProvider(creds));
+                  AwsBasicCredentials creds = AwsBasicCredentials.create(awsAccessKey, awsSecretKey);
+                  builder.credentialsProvider(StaticCredentialsProvider.create(creds));
                }
 
                firehoseClient = builder.build();

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
@@ -1,13 +1,9 @@
 package io.rcktapp.api.handler.firehose;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClientBuilder;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsRequest;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsResult;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
-import com.amazonaws.services.kinesisfirehose.model.Record;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
+import software.amazon.awssdk.services.firehose.model.Record;
 import io.forty11.web.js.JSArray;
 import io.forty11.web.js.JSObject;
 import io.rcktapp.api.Action;
@@ -23,11 +19,8 @@ import io.rcktapp.api.SC;
 import io.rcktapp.api.Table;
 import io.rcktapp.api.service.Service;
 
-import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * Posts records to a mapped AWS Kinesis Firehose stream.
@@ -50,70 +43,16 @@ import java.util.concurrent.Future;
  * <code>separator</code> will be appended to the record.
  * <p>
  * The underlying Firehose stream is mapped to the collection name through
- * the FireshoseDb.includeStreams property.
+ * the FirehoseDb.includeStreams property.
  *
  * @author wells
  */
 public class FirehosePostHandler implements Handler
 {
-    public static final String upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    public static final String lower = upper.toLowerCase();
-    public static final String digits = "0123456789";
-    public static final char[] symbols = (upper + lower + digits).toCharArray();
-    static SecureRandom random = new SecureRandom();
     protected int     batchMax     = 500;
     protected int     fieldCharMax = 10000;
     protected String  separator    = "\n";
     protected boolean prettyPrint  = false;
-
-    public static String randomString(int size)
-    {
-
-        char[] buf = new char[size];
-        for (int idx = 0; idx < buf.length; ++idx)
-            buf[idx] = symbols[random.nextInt(symbols.length)];
-        return new String(buf);
-    }
-
-    public static void main(String[] args) throws Exception
-    {
-        System.out.println(randomString(100));
-
-        AmazonKinesisFirehose firehose = AmazonKinesisFirehoseClientBuilder.defaultClient();
-
-        ListDeliveryStreamsRequest listDeliveryStreamsRequest = new ListDeliveryStreamsRequest();
-        ListDeliveryStreamsResult listDeliveryStreamsResult = firehose.listDeliveryStreams(listDeliveryStreamsRequest);
-        List<String> deliveryStreamNames = listDeliveryStreamsResult.getDeliveryStreamNames();
-        while (listDeliveryStreamsResult.isHasMoreDeliveryStreams())
-        {
-            if (deliveryStreamNames.size() > 0)
-            {
-                listDeliveryStreamsRequest.setExclusiveStartDeliveryStreamName(deliveryStreamNames.get(deliveryStreamNames.size() - 1));
-            }
-            listDeliveryStreamsResult = firehose.listDeliveryStreams(listDeliveryStreamsRequest);
-            deliveryStreamNames.addAll(listDeliveryStreamsResult.getDeliveryStreamNames());
-        }
-
-        System.out.println(deliveryStreamNames);
-
-        for (int i = 0; i < 2000; i++)
-        {
-            List<Record> records = new ArrayList();
-            for (int j = 0; j < 500; j++)
-            {
-                JSObject json = new JSObject("tenantCode", "us", "yearid", 2019, "monthid", 201901, "dayid", 20190110, "locationCode", "asdfasdf", "playerCode", "us-12345667-1", "adId", (i * j), "somecrapproperrty", randomString(500));
-                records.add(new Record().withData(ByteBuffer.wrap((json.toString(false).trim() + "\n").getBytes())));
-            }
-
-            PutRecordBatchRequest put = new PutRecordBatchRequest();
-            put.setDeliveryStreamName("liftck-player9-impression");
-            put.setRecords(records);
-            firehose.putRecordBatch(put);
-
-            System.out.println(i);
-        }
-
-    }
 
     @Override
     public void service(Service service, Api api, Endpoint endpoint, Action action, Chain chain, Request req, Response res) throws Exception
@@ -126,7 +65,7 @@ public class FirehosePostHandler implements Handler
         Table table = col.getEntity().getTable();
         String streamName = table.getName();
 
-        AmazonKinesisFirehoseAsync firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
+        FirehoseClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
 
         JSObject body = req.getJson();
 
@@ -171,17 +110,17 @@ public class FirehosePostHandler implements Handler
                 if (separator != null && !string.endsWith(separator))
                     string += separator;
 
-                batch.add(new Record().withData(ByteBuffer.wrap(string.getBytes())));
+                batch.add(Record.builder().data(SdkBytes.fromByteArray(string.getBytes())).build());
 
                 if ((i + 1) % batchMax == 0)
                 {
-                    firehose.putRecordBatchAsync(new PutRecordBatchRequest().withDeliveryStreamName(streamName).withRecords(batch));
+                    firehose.putRecordBatch(PutRecordBatchRequest.builder().deliveryStreamName(streamName).records(batch).build());
                     batch = new ArrayList<>();
                 }
             }
 
             if (!batch.isEmpty())
-                firehose.putRecordBatchAsync(new PutRecordBatchRequest().withDeliveryStreamName(streamName).withRecords(batch));
+                firehose.putRecordBatch(PutRecordBatchRequest.builder().deliveryStreamName(streamName).records(batch).build());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Summary

- Replaces `aws-java-sdk-kinesis:1.11.390` with `software.amazon.awssdk:firehose:2.41.34`
- Migrates `FirehoseDb` client construction to SDK v2 (`FirehoseClient.builder()`, `AwsBasicCredentials`, `StaticCredentialsProvider`, `Region.of()`)
- Migrates `FirehosePostHandler` to SDK v2 `Record`/`PutRecordBatchRequest` builder pattern; `putRecordBatchAsync` → `putRecordBatch`
- Removes hardcoded load-test `main()` method and associated dead code (`randomString`, `upper`, `lower`, `digits`, `symbols`)
- Fixes typo in javadoc (`FireshoseDb` → `FirehoseDb`)
- Bumps version `0.3.6.15` → `0.3.6.16`

## Test plan

- [x] `./gradlew compileJava` passes
- [x] `./gradlew test` passes (5 tests)
- [x] Deploy to non-prod via `liftck_snooze` and confirm all 10 Firehose streams receive records
- [x] Monitor CloudWatch for successful `PutRecordBatch` calls

## Notes

⚠️ **Downstream impact:** `liftck_snooze` (`FirehoseDbConfig`) overrides `getFirehoseClient()` — return type changed from `AmazonKinesisFirehoseAsync` to `FirehoseClient`. That service must be updated before its integration tests will pass.