### PR TITLE
LIFT-1806: Upgrade Firehose to AWS SDK v2 (0.3.x)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [0.3.26 - 03/30/26]
+- LIFT-1806: Upgrade Firehose to AWS SDK v2
+
 ## [0.3.24 - 03/17/26]
 - LIFT-1805: AWS DydnamoDB SDK V2 Upgrade
 - LIFT-1804: fix etag capitalization from s3 sdk v2 upgrade

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ project.docsDirName = '../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.24'
+version = '0.3.25'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
@@ -143,6 +143,7 @@ dependencies {
 
     api "software.amazon.awssdk:s3:$awsSdkV2Version"
     api "software.amazon.awssdk:dynamodb:$awsSdkV2Version"
+    api "software.amazon.awssdk:firehose:$awsSdkV2Version"
     api 'com.amazonaws:aws-java-sdk-kinesis:1.11.390'
     api 'com.amazonaws:aws-java-sdk-rds:1.11.542'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ project.docsDirName = '../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.25'
+version = '0.3.26'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
@@ -1,11 +1,13 @@
 package io.rcktapp.api.handler.firehose;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsyncClientBuilder;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsRequest;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsResult;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.FirehoseClientBuilder;
+import software.amazon.awssdk.services.firehose.model.DeliveryStreamType;
+import software.amazon.awssdk.services.firehose.model.ListDeliveryStreamsRequest;
+import software.amazon.awssdk.services.firehose.model.ListDeliveryStreamsResponse;
 import io.forty11.j.J;
 import io.rcktapp.api.Collection;
 import io.rcktapp.api.Db;
@@ -46,7 +48,7 @@ public class FirehoseDb extends Db
      */
     protected String includeStreams;
 
-    AmazonKinesisFirehoseAsync firehoseClient = null;
+    FirehoseClient firehoseClient = null;
 
     public FirehoseDb() {
         super();
@@ -101,7 +103,7 @@ public class FirehoseDb extends Db
 
     private List<String> listAllDeliveryStreamNames() {
 
-        ListDeliveryStreamsResult listDeliveryStreamsResult;
+        ListDeliveryStreamsResponse listDeliveryStreamsResponse;
         List<String> deliveryStreamNames = new ArrayList<>();
 
         do {
@@ -109,32 +111,35 @@ public class FirehoseDb extends Db
 
             ListDeliveryStreamsRequest listDeliveryStreamsRequest = getRequest(last);
 
-            listDeliveryStreamsResult = getFirehoseClient().listDeliveryStreams(listDeliveryStreamsRequest);
+            listDeliveryStreamsResponse = getFirehoseClient().listDeliveryStreams(listDeliveryStreamsRequest);
 
-            deliveryStreamNames.addAll(listDeliveryStreamsResult.getDeliveryStreamNames());
+            deliveryStreamNames.addAll(listDeliveryStreamsResponse.deliveryStreamNames());
 
-        } while (listDeliveryStreamsResult.getHasMoreDeliveryStreams());
+        } while (listDeliveryStreamsResponse.hasMoreDeliveryStreams());
 
         return deliveryStreamNames;
     }
 
     ListDeliveryStreamsRequest getRequest(String lastEntry) {
-        return new ListDeliveryStreamsRequest()
-                .withDeliveryStreamType("DirectPut")
-                .withExclusiveStartDeliveryStreamName(lastEntry);
+        ListDeliveryStreamsRequest.Builder builder = ListDeliveryStreamsRequest.builder()
+                .deliveryStreamType(DeliveryStreamType.DIRECT_PUT);
+        if (lastEntry != null) {
+            builder.exclusiveStartDeliveryStreamName(lastEntry);
+        }
+        return builder.build();
     }
 
-    public AmazonKinesisFirehoseAsync getFirehoseClient() {
+    public FirehoseClient getFirehoseClient() {
         if (this.firehoseClient == null) {
             synchronized (this) {
                 if (this.firehoseClient == null) {
-                    AmazonKinesisFirehoseAsyncClientBuilder builder = AmazonKinesisFirehoseAsyncClientBuilder.standard();
+                    FirehoseClientBuilder builder = FirehoseClient.builder();
                     if (!J.empty(awsRegion))
-                        builder.withRegion(awsRegion);
+                        builder.region(Region.of(awsRegion));
 
                     if (!J.empty(awsAccessKey) && !J.empty(awsSecretKey)) {
-                        BasicAWSCredentials creds = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
-                        builder.withCredentials(new AWSStaticCredentialsProvider(creds));
+                        AwsBasicCredentials creds = AwsBasicCredentials.create(awsAccessKey, awsSecretKey);
+                        builder.credentialsProvider(StaticCredentialsProvider.create(creds));
                     }
 
                     firehoseClient = builder.build();

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
@@ -1,13 +1,9 @@
 package io.rcktapp.api.handler.firehose;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClientBuilder;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsRequest;
-import com.amazonaws.services.kinesisfirehose.model.ListDeliveryStreamsResult;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
-import com.amazonaws.services.kinesisfirehose.model.Record;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
+import software.amazon.awssdk.services.firehose.model.Record;
 import io.forty11.web.js.JSArray;
 import io.forty11.web.js.JSObject;
 import io.rcktapp.api.Action;
@@ -23,11 +19,8 @@ import io.rcktapp.api.SC;
 import io.rcktapp.api.Table;
 import io.rcktapp.api.service.Service;
 
-import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * Posts records to a mapped AWS Kinesis Firehose stream.
@@ -51,29 +44,15 @@ import java.util.concurrent.Future;
  * <p>
  * The underlying Firehose stream may be mapped to the collection name through
  * the FirehoseDb.includeStreams property.
- ho
+ *
  * @author wells
  */
 public class FirehosePostHandler implements Handler
 {
-    public static final String upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    public static final String lower = upper.toLowerCase();
-    public static final String digits = "0123456789";
-    public static final char[] symbols = (upper + lower + digits).toCharArray();
-    static SecureRandom random = new SecureRandom();
     protected int     batchMax     = 500;
     protected int     fieldCharMax = 10000;
     protected String  separator    = "\n";
     protected boolean prettyPrint  = false;
-
-    public static String randomString(int size)
-    {
-
-        char[] buf = new char[size];
-        for (int idx = 0; idx < buf.length; ++idx)
-            buf[idx] = symbols[random.nextInt(symbols.length)];
-        return new String(buf);
-    }
 
     @Override
     public void service(Service service, Api api, Endpoint endpoint, Action action, Chain chain, Request req, Response res) throws Exception
@@ -86,7 +65,7 @@ public class FirehosePostHandler implements Handler
         Table table = col.getEntity().getTable();
         String streamName = table.getName();
 
-        AmazonKinesisFirehoseAsync firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
+        FirehoseClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
 
         JSObject body = req.getJson();
 
@@ -131,17 +110,17 @@ public class FirehosePostHandler implements Handler
                 if (separator != null && !string.endsWith(separator))
                     string += separator;
 
-                batch.add(new Record().withData(ByteBuffer.wrap(string.getBytes())));
+                batch.add(Record.builder().data(SdkBytes.fromByteArray(string.getBytes())).build());
 
                 if ((i + 1) % batchMax == 0)
                 {
-                    firehose.putRecordBatchAsync(new PutRecordBatchRequest().withDeliveryStreamName(streamName).withRecords(batch));
+                    firehose.putRecordBatch(PutRecordBatchRequest.builder().deliveryStreamName(streamName).records(batch).build());
                     batch = new ArrayList<>();
                 }
             }
 
             if (!batch.isEmpty())
-                firehose.putRecordBatchAsync(new PutRecordBatchRequest().withDeliveryStreamName(streamName).withRecords(batch));
+                firehose.putRecordBatch(PutRecordBatchRequest.builder().deliveryStreamName(streamName).records(batch).build());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Summary

- Adds `software.amazon.awssdk:firehose:2.41.34`; retains `aws-java-sdk-kinesis:1.11.390` for `DataStreamDb`/`DataStreamPostHandler` (Kinesis Data Streams — out of scope)
- Migrates `FirehoseDb` including `listAllDeliveryStreamNames()` and `getRequest()`: `ListDeliveryStreamsResult` → `ListDeliveryStreamsResponse`, accessor methods updated to SDK v2 style, `withDeliveryStreamType`/`withExclusiveStartDeliveryStreamName` → builder with `DeliveryStreamType.DIRECT_PUT` enum + null guard
- Migrates `FirehosePostHandler` to SDK v2 `Record`/`PutRecordBatchRequest` builder pattern; `putRecordBatchAsync` → `putRecordBatch`
- Removes dead code (`randomString`, `upper`, `lower`, `digits`, `symbols`) left over from previously deleted `main()` method
- Fixes stray `ho` text in javadoc
- Bumps version `0.3.25` → `0.3.26`

## Test plan

- [x] `./gradlew compileJava` passes
- [x] `./gradlew test` passes
- [x] Confirm `DataStreamDb`/`DataStreamPostHandler` still compile (v1 kinesis retained)
- [x] Deploy to non-prod and confirm `listAllDeliveryStreamNames()` correctly discovers `DirectPut` streams on bootstrap
- [x] Verify `allowPattern`/`denyPattern` filtering works during bootstrap
- [x] Monitor CloudWatch for successful `PutRecordBatch` calls

## Notes

⚠️ **Downstream impact:** `liftck_heartbeat` (`FirehoseDbConfig`) overrides `getFirehoseClient()` — return type changed from `AmazonKinesisFirehoseAsync` to `FirehoseClient`. That service must be updated before its integration tests will pass.