### PR TITLE
LIFT-2099: Add relevance scoring to wildcard search queries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## [0.3.6.19 - 04/05/26]
+## [0.3.6.17 - 04/05/26]
 - LIFT-2099: Add relevance scoring to wildcard search queries (w, sw, ew operators)
   - Wildcard queries now include match queries in `should` for TF-IDF/BM25 relevance scoring
   - `_score` added as secondary sort when search terms are present

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## [0.3.6.19 - 04/05/26]
+- LIFT-2099: Add relevance scoring to wildcard search queries (w, sw, ew operators)
+  - Wildcard queries now include match queries in `should` for TF-IDF/BM25 relevance scoring
+  - `_score` added as secondary sort when search terms are present
+  - Fixed multi-value wildcard queries restoring OR semantics (e.g. sw(city,Chand,Atl) matches either value)
+  - Fixed `_score` sort serialization (removed unsupported `missing` parameter)
+
 ## [0.3.6.16 - 03/30/26]
 - LIFT-1807: Upgrade RDS IAM auth token generation to AWS SDK v2
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.16'
+version = '0.3.6.17'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.19'
+version = '0.3.6.17'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.17'
+version = '0.3.6.18'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.18'
+version = '0.3.6.19'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
+++ b/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
@@ -161,43 +161,68 @@ public class BoolQuery extends ElasticQuery
          }
          else if (elastic instanceof BoolQuery)
          {
-            // When a nested BoolQuery has 'should' clauses for relevance scoring,
-            // hoist them to this outer BoolQuery instead of nesting in filter context
-            // (filter context disables scoring)
             BoolQuery innerBool = (BoolQuery) elastic;
 
-            // Hoist filter clauses
-            if (innerBool.getFilter() != null)
+            // Only hoist clauses if this BoolQuery has relevance-scoring should clauses
+            // (i.e., should clauses containing MatchQuery). Otherwise, keep it nested
+            // to preserve the original query structure.
+            if (hasRelevanceScoringShould(innerBool))
             {
-               for (ElasticQuery filterItem : innerBool.getFilter())
-                  addFilter(filterItem);
-            }
+               // Hoist filter clauses
+               if (innerBool.getFilter() != null)
+               {
+                  for (ElasticQuery filterItem : innerBool.getFilter())
+                     addFilter(filterItem);
+               }
 
-            // Hoist should clauses (preserves relevance scoring)
-            if (innerBool.getShould() != null)
-            {
-               for (ElasticQuery shouldItem : innerBool.getShould())
-                  addShould(shouldItem);
-            }
+               // Hoist should clauses (preserves relevance scoring)
+               if (innerBool.getShould() != null)
+               {
+                  for (ElasticQuery shouldItem : innerBool.getShould())
+                     addShould(shouldItem);
+               }
 
-            // Hoist must clauses
-            if (innerBool.getMust() != null)
-            {
-               for (ElasticQuery mustItem : innerBool.getMust())
-                  addMust(mustItem);
-            }
+               // Hoist must clauses
+               if (innerBool.getMust() != null)
+               {
+                  for (ElasticQuery mustItem : innerBool.getMust())
+                     addMust(mustItem);
+               }
 
-            // Hoist must_not clauses
-            if (innerBool.getMustNot() != null)
+               // Hoist must_not clauses
+               if (innerBool.getMustNot() != null)
+               {
+                  for (ElasticQuery mustNotItem : innerBool.getMustNot())
+                     addMustNot(mustNotItem);
+               }
+            }
+            else
             {
-               for (ElasticQuery mustNotItem : innerBool.getMustNot())
-                  addMustNot(mustNotItem);
+               // Keep the BoolQuery nested in filter context (original behavior)
+               addFilter(elastic);
             }
          }
          else
             addFilter(elastic);
       }
 
+   }
+
+   /**
+    * Checks if this BoolQuery has should clauses that contribute to relevance scoring.
+    * This is true when there are MatchQuery objects in the should list.
+    */
+   private boolean hasRelevanceScoringShould(BoolQuery bool)
+   {
+      if (bool.getShould() == null || bool.getShould().isEmpty())
+         return false;
+
+      for (ElasticQuery shouldItem : bool.getShould())
+      {
+         if (shouldItem instanceof MatchQuery)
+            return true;
+      }
+      return false;
    }
 
    private List<Map<String, ElasticQuery>> getListForElasticJson(List<ElasticQuery> queryList)

--- a/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
+++ b/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
@@ -194,6 +194,8 @@ public class BoolQuery extends ElasticQuery
             jsonList.add(Collections.singletonMap("exists", elastic));
          else if (elastic instanceof FuzzyQuery)
             jsonList.add(Collections.singletonMap("fuzzy", elastic));
+         else if (elastic instanceof MatchQuery)
+            jsonList.add(Collections.singletonMap("match", elastic));
       }
 
       return jsonList;

--- a/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
+++ b/src/main/java/io/rcktapp/rql/elastic/BoolQuery.java
@@ -128,7 +128,7 @@ public class BoolQuery extends ElasticQuery
             if (nestedList.size() > 1)
             {
                BoolQuery bool = new BoolQuery();
-               
+
                // move the filters from each nest to this nested query
                for (ElasticQuery nest : nestedList)
                {
@@ -158,6 +158,41 @@ public class BoolQuery extends ElasticQuery
             // add this new object to a filter.
             addFilter(elastic);
 
+         }
+         else if (elastic instanceof BoolQuery)
+         {
+            // When a nested BoolQuery has 'should' clauses for relevance scoring,
+            // hoist them to this outer BoolQuery instead of nesting in filter context
+            // (filter context disables scoring)
+            BoolQuery innerBool = (BoolQuery) elastic;
+
+            // Hoist filter clauses
+            if (innerBool.getFilter() != null)
+            {
+               for (ElasticQuery filterItem : innerBool.getFilter())
+                  addFilter(filterItem);
+            }
+
+            // Hoist should clauses (preserves relevance scoring)
+            if (innerBool.getShould() != null)
+            {
+               for (ElasticQuery shouldItem : innerBool.getShould())
+                  addShould(shouldItem);
+            }
+
+            // Hoist must clauses
+            if (innerBool.getMust() != null)
+            {
+               for (ElasticQuery mustItem : innerBool.getMust())
+                  addMust(mustItem);
+            }
+
+            // Hoist must_not clauses
+            if (innerBool.getMustNot() != null)
+            {
+               for (ElasticQuery mustNotItem : innerBool.getMustNot())
+                  addMustNot(mustNotItem);
+            }
          }
          else
             addFilter(elastic);

--- a/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
+++ b/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
@@ -336,9 +336,13 @@ public class ElasticRql extends Rql
    }
 
    /**
-    * 
+    * Creates a hybrid query with both wildcard (for substring matching) and match (for relevance scoring).
+    *
+    * The wildcard in filter ensures documents contain the substring (preserves existing behavior).
+    * The match in should adds relevance scoring so exact token matches rank higher.
+    *
     * @param pred
-    * @param withType WITH, STARTS_WITH, ENDS_WITH
+    * @param withType WITH, STARTS_WITH, ENDS_WITH, WITHOUT
     */
    private BoolQuery withWildCardPopulater(Predicate pred, WithType withType)
    {
@@ -346,19 +350,27 @@ public class ElasticRql extends Rql
       String termToken = pred.terms.get(0).token;
       for (int i = 1; i < pred.terms.size(); i++)
       {
+         String dequotedValue = Parser.dequote(pred.terms.get(i).token);
+
          switch (withType)
          {
             case WITH:
-               bq.addShould(new Wildcard(termToken, "*" + Parser.dequote(pred.terms.get(i).token) + "*"));
+               // Filter: ensures substring match (preserves current behavior)
+               bq.addFilter(new Wildcard(termToken, "*" + dequotedValue + "*"));
+               // Should: adds relevance scoring for exact token matches
+               bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case STARTS_WITH:
-               bq.addShould(new Wildcard(termToken, Parser.dequote(pred.terms.get(i).token) + "*"));
+               bq.addFilter(new Wildcard(termToken, dequotedValue + "*"));
+               bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case ENDS_WITH:
-               bq.addShould(new Wildcard(termToken, "*" + Parser.dequote(pred.terms.get(i).token)));
+               bq.addFilter(new Wildcard(termToken, "*" + dequotedValue));
+               bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case WITHOUT:
-               bq.addMustNot(new Wildcard(termToken, "*" + Parser.dequote(pred.terms.get(i).token) + "*"));
+               // WITHOUT is a negative match - no relevance scoring needed
+               bq.addMustNot(new Wildcard(termToken, "*" + dequotedValue + "*"));
          }
       }
       return bq;

--- a/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
+++ b/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
@@ -124,17 +124,31 @@ public class ElasticRql extends Rql
       // because we are starting the search after 'AL'
       io.rcktapp.rql.elastic.Order elasticOrder = null;
       List<Order> orderList = stmt.order;
-      //      if (orderList.size() > 0)
-      //      {
+
+      // Check if this query involves relevance scoring (has search terms)
+      // If so, add _score as secondary sort so relevant results rank higher within ties
+      boolean hasRelevanceScoring = hasRelevanceScoringQueries(elasticList);
+      boolean scoreSortExists = false;
+
       boolean idSortExists = false;
       for (Order order : orderList)
       {
          if (Parser.dequote(order.col).equalsIgnoreCase("id"))
             idSortExists = true;
+         if (Parser.dequote(order.col).equalsIgnoreCase("_score"))
+            scoreSortExists = true;
       }
       if (!idSortExists)
          orderList.add(new Order("id", "asc"));
-      //      }
+
+      // Add _score desc as secondary sort when searching (before id, after user's primary sort)
+      if (hasRelevanceScoring && !scoreSortExists)
+      {
+         // Insert _score before the id sort (which is last)
+         int insertIndex = orderList.size() - 1; // before id
+         orderList.add(insertIndex, new Order("_score", "desc"));
+      }
+
       for (int i = 0; i < orderList.size(); i++)
       {
          Order order = orderList.get(i);
@@ -197,6 +211,31 @@ public class ElasticRql extends Rql
          bool.divvyElasticList(elasticList);
          dsl.setBool(bool);
       }
+   }
+
+   /**
+    * Checks if any of the ElasticQuery objects involve relevance scoring.
+    * This is true when there are BoolQuery objects with 'should' clauses containing MatchQuery,
+    * which are created by the wildcard search functions (w, sw, ew) for relevance ranking.
+    */
+   private boolean hasRelevanceScoringQueries(List<ElasticQuery> elasticList)
+   {
+      for (ElasticQuery elastic : elasticList)
+      {
+         if (elastic instanceof BoolQuery)
+         {
+            BoolQuery bool = (BoolQuery) elastic;
+            if (bool.getShould() != null && !bool.getShould().isEmpty())
+            {
+               for (ElasticQuery shouldItem : bool.getShould())
+               {
+                  if (shouldItem instanceof MatchQuery)
+                     return true;
+               }
+            }
+         }
+      }
+      return false;
    }
 
    private ElasticQuery convertPredicate(Predicate pred) throws Exception

--- a/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
+++ b/src/main/java/io/rcktapp/rql/elastic/ElasticRql.java
@@ -225,7 +225,7 @@ public class ElasticRql extends Rql
          if (elastic instanceof BoolQuery)
          {
             BoolQuery bool = (BoolQuery) elastic;
-            if (bool.getShould() != null && !bool.getShould().isEmpty())
+            if (bool.getShould() != null)
             {
                for (ElasticQuery shouldItem : bool.getShould())
                {
@@ -387,6 +387,8 @@ public class ElasticRql extends Rql
    {
       BoolQuery bq = new BoolQuery();
       String termToken = pred.terms.get(0).token;
+      List<Wildcard> wildcards = new ArrayList<Wildcard>();
+
       for (int i = 1; i < pred.terms.size(); i++)
       {
          String dequotedValue = Parser.dequote(pred.terms.get(i).token);
@@ -394,24 +396,42 @@ public class ElasticRql extends Rql
          switch (withType)
          {
             case WITH:
-               // Filter: ensures substring match (preserves current behavior)
-               bq.addFilter(new Wildcard(termToken, "*" + dequotedValue + "*"));
-               // Should: adds relevance scoring for exact token matches
+               wildcards.add(new Wildcard(termToken, "*" + dequotedValue + "*"));
                bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case STARTS_WITH:
-               bq.addFilter(new Wildcard(termToken, dequotedValue + "*"));
+               wildcards.add(new Wildcard(termToken, dequotedValue + "*"));
                bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case ENDS_WITH:
-               bq.addFilter(new Wildcard(termToken, "*" + dequotedValue));
+               wildcards.add(new Wildcard(termToken, "*" + dequotedValue));
                bq.addShould(new MatchQuery(termToken, dequotedValue));
                break;
             case WITHOUT:
-               // WITHOUT is a negative match - no relevance scoring needed
                bq.addMustNot(new Wildcard(termToken, "*" + dequotedValue + "*"));
          }
       }
+
+      if (!wildcards.isEmpty())
+      {
+         if (wildcards.size() == 1)
+         {
+            // Single value: wildcard directly in filter (boolean match required)
+            bq.addFilter(wildcards.get(0));
+         }
+         else
+         {
+            // Multi-value: wrap wildcards in inner should for OR semantics.
+            // An inner bool with only should clauses defaults minimum_should_match=1,
+            // so at least one wildcard must match (OR, not AND).
+            // This preserves OR semantics even when combined with outer filter clauses.
+            BoolQuery wildcardBq = new BoolQuery();
+            for (Wildcard wildcard : wildcards)
+               wildcardBq.addShould(wildcard);
+            bq.addFilter(wildcardBq);
+         }
+      }
+
       return bq;
    }
 }

--- a/src/main/java/io/rcktapp/rql/elastic/MatchQuery.java
+++ b/src/main/java/io/rcktapp/rql/elastic/MatchQuery.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015-2018 Rocket Partners, LLC
+ * http://rocketpartners.io
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.rcktapp.rql.elastic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Elasticsearch match query for relevance-scored full-text search.
+ * Unlike wildcard queries which don't contribute to scoring, match queries
+ * use TF-IDF/BM25 scoring to rank results by relevance.
+ */
+public class MatchQuery extends ElasticQuery
+{
+   @JsonIgnore
+   private String name;
+
+   @JsonIgnore
+   private Object value;
+
+   public MatchQuery(String name, Object value)
+   {
+      this.name = name;
+      this.value = value;
+
+      if (name.contains("."))
+      {
+         this.nestedPath = name.substring(0, name.lastIndexOf("."));
+      }
+   }
+
+   /**
+    * Outputs JSON in the format:
+    * {
+    *    "fieldName": "value"
+    * }
+    *
+    * Which becomes when wrapped:
+    * {
+    *    "match": {
+    *       "fieldName": "value"
+    *    }
+    * }
+    */
+   @JsonAnyGetter
+   public Map<String, Object> any()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(name, value);
+      return properties;
+   }
+
+   /**
+    * @return the name
+    */
+   public String getName()
+   {
+      return name;
+   }
+
+   /**
+    * @return the value
+    */
+   public Object getValue()
+   {
+      return value;
+   }
+}

--- a/src/main/java/io/rcktapp/rql/elastic/Order.java
+++ b/src/main/java/io/rcktapp/rql/elastic/Order.java
@@ -113,7 +113,10 @@ public class Order
 
             Map<String, String> newEntry = new HashMap();
             newEntry.put("order", order);
-            newEntry.put("missing", "desc".equalsIgnoreCase(order) ? "_last": "_first");
+            // _score doesn't support the "missing" parameter in Elasticsearch
+            if (!"_score".equals(property)) {
+               newEntry.put("missing", "desc".equalsIgnoreCase(order) ? "_last": "_first");
+            }
 
             Map<String, Map> newOrderEntry = new HashMap<>();
             newOrderEntry.put(property, newEntry);

--- a/src/test/java/io/rcktapp/rql/TestElasticRql.java
+++ b/src/test/java/io/rcktapp/rql/TestElasticRql.java
@@ -96,15 +96,14 @@ public class TestElasticRql
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
 
-         // Filter contains Wildcards for matching
-         assertEquals(2, dsl.getBool().getFilter().size());
-         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+         // Filter contains an inner BoolQuery with wildcards in should (OR semantics)
+         assertEquals(1, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof BoolQuery);
 
-         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
-
-         assertEquals("city", wildcard.getName());
-         assertEquals("Chand*", wildcard.getValue());
-         assertNull(wildcard.getNestedPath());
+         BoolQuery wildcardBq = (BoolQuery) dsl.getBool().getFilter().get(0);
+         assertEquals(2, wildcardBq.getShould().size());
+         assertTrue(wildcardBq.getShould().get(0) instanceof Wildcard);
+         assertEquals("Chand*", ((Wildcard) wildcardBq.getShould().get(0)).getValue());
 
          // Should contains MatchQuery for relevance scoring
          assertEquals(2, dsl.getBool().getShould().size());
@@ -114,7 +113,7 @@ public class TestElasticRql
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"city\":\"Chand*\"}},{\"wildcard\":{\"city\":\"Atl*\"}}],\"should\":[{\"match\":{\"city\":\"Chand\"}},{\"match\":{\"city\":\"Atl\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"bool\":{\"should\":[{\"wildcard\":{\"city\":\"Chand*\"}},{\"wildcard\":{\"city\":\"Atl*\"}}]}}],\"should\":[{\"match\":{\"city\":\"Chand\"}},{\"match\":{\"city\":\"Atl\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -189,21 +188,15 @@ public class TestElasticRql
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
 
-         // Filter contains Wildcards for matching
-         assertEquals(2, dsl.getBool().getFilter().size());
-         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+         // Filter contains an inner BoolQuery with wildcards in should (OR semantics)
+         assertEquals(1, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof BoolQuery);
 
-         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
-
-         assertEquals("name", wildcard.getName());
-         assertEquals("*nestl*", wildcard.getValue());
-         assertNull(wildcard.getNestedPath());
-
-         wildcard = (Wildcard)dsl.getBool().getFilter().get(1);
-
-         assertEquals("name", wildcard.getName());
-         assertEquals("*f'*", wildcard.getValue());
-         assertNull(wildcard.getNestedPath());
+         BoolQuery wildcardBq = (BoolQuery) dsl.getBool().getFilter().get(0);
+         assertEquals(2, wildcardBq.getShould().size());
+         assertTrue(wildcardBq.getShould().get(0) instanceof Wildcard);
+         assertEquals("*nestl*", ((Wildcard) wildcardBq.getShould().get(0)).getValue());
+         assertEquals("*f'*", ((Wildcard) wildcardBq.getShould().get(1)).getValue());
 
          // Should contains MatchQuery for relevance scoring
          assertEquals(2, dsl.getBool().getShould().size());
@@ -213,7 +206,7 @@ public class TestElasticRql
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"name\":\"*nestl*\"}},{\"wildcard\":{\"name\":\"*f'*\"}}],\"should\":[{\"match\":{\"name\":\"nestl\"}},{\"match\":{\"name\":\"f'\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"bool\":{\"should\":[{\"wildcard\":{\"name\":\"*nestl*\"}},{\"wildcard\":{\"name\":\"*f'*\"}}]}}],\"should\":[{\"match\":{\"name\":\"nestl\"}},{\"match\":{\"name\":\"f'\"}}]}}", json);
 
       }
       catch (Exception e)

--- a/src/test/java/io/rcktapp/rql/TestElasticRql.java
+++ b/src/test/java/io/rcktapp/rql/TestElasticRql.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.rcktapp.rql.elastic.BoolQuery;
 import io.rcktapp.rql.elastic.ElasticQuery;
 import io.rcktapp.rql.elastic.ElasticRql;
+import io.rcktapp.rql.elastic.MatchQuery;
 import io.rcktapp.rql.elastic.NestedQuery;
 import io.rcktapp.rql.elastic.QueryDsl;
 import io.rcktapp.rql.elastic.Range;
@@ -90,25 +91,30 @@ public class TestElasticRql
          assertNull(dsl.getWildcard());
          assertNotNull(dsl.getBool());  // A bool is used because comma separated values are valid for all 'with' functions
          
-         assertNull(dsl.getBool().getFilter());
+         assertNotNull(dsl.getBool().getFilter());
          assertNull(dsl.getBool().getMust());
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
-         
-         assertEquals(2, dsl.getBool().getShould().size());
-         assertTrue(dsl.getBool().getShould().get(0) instanceof Wildcard);
-         
-         Wildcard wildcard = (Wildcard)dsl.getBool().getShould().get(0);
+
+         // Filter contains Wildcards for matching
+         assertEquals(2, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+
+         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
 
          assertEquals("city", wildcard.getName());
          assertEquals("Chand*", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
 
+         // Should contains MatchQuery for relevance scoring
+         assertEquals(2, dsl.getBool().getShould().size());
+         assertTrue(dsl.getBool().getShould().get(0) instanceof MatchQuery);
+
          ObjectMapper mapper = new ObjectMapper();
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"should\":[{\"wildcard\":{\"city\":\"Chand*\"}},{\"wildcard\":{\"city\":\"Atl*\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"city\":\"Chand*\"}},{\"wildcard\":{\"city\":\"Atl*\"}}],\"should\":[{\"match\":{\"city\":\"Chand\"}},{\"match\":{\"city\":\"Atl\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -131,26 +137,31 @@ public class TestElasticRql
          assertNull(dsl.getTerm());
          assertNull(dsl.getWildcard());
          assertNotNull(dsl.getBool());  // A bool is used because comma separated values are valid for all 'with' functions
-         
-         assertNull(dsl.getBool().getFilter());
+
+         assertNotNull(dsl.getBool().getFilter());
          assertNull(dsl.getBool().getMust());
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
-         
-         assertEquals(1, dsl.getBool().getShould().size());
-         assertTrue(dsl.getBool().getShould().get(0) instanceof Wildcard);
-         
-         Wildcard wildcard = (Wildcard)dsl.getBool().getShould().get(0);
+
+         // Filter contains Wildcard for matching
+         assertEquals(1, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+
+         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
 
          assertEquals("city", wildcard.getName());
          assertEquals("*andl*", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
 
+         // Should contains MatchQuery for relevance scoring
+         assertEquals(1, dsl.getBool().getShould().size());
+         assertTrue(dsl.getBool().getShould().get(0) instanceof MatchQuery);
+
          ObjectMapper mapper = new ObjectMapper();
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull(json, "json should not be empty.");
-         assertEquals("{\"bool\":{\"should\":[{\"wildcard\":{\"city\":\"*andl*\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"city\":\"*andl*\"}}],\"should\":[{\"match\":{\"city\":\"andl\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -172,32 +183,37 @@ public class TestElasticRql
          assertNull(dsl.getTerm());
          assertNull(dsl.getWildcard());
          assertNotNull(dsl.getBool());  // A bool is used because comma separated values are valid for all 'with' functions
-         
-         assertNull(dsl.getBool().getFilter());
+
+         assertNotNull(dsl.getBool().getFilter());
          assertNull(dsl.getBool().getMust());
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
-         
-         assertEquals(2, dsl.getBool().getShould().size());
-         assertTrue(dsl.getBool().getShould().get(0) instanceof Wildcard);
-         
-         Wildcard wildcard = (Wildcard)dsl.getBool().getShould().get(0);
+
+         // Filter contains Wildcards for matching
+         assertEquals(2, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+
+         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
 
          assertEquals("name", wildcard.getName());
          assertEquals("*nestl*", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
-         
-         wildcard = (Wildcard)dsl.getBool().getShould().get(1);
+
+         wildcard = (Wildcard)dsl.getBool().getFilter().get(1);
 
          assertEquals("name", wildcard.getName());
          assertEquals("*f'*", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
 
+         // Should contains MatchQuery for relevance scoring
+         assertEquals(2, dsl.getBool().getShould().size());
+         assertTrue(dsl.getBool().getShould().get(0) instanceof MatchQuery);
+
          ObjectMapper mapper = new ObjectMapper();
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"should\":[{\"wildcard\":{\"name\":\"*nestl*\"}},{\"wildcard\":{\"name\":\"*f'*\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"name\":\"*nestl*\"}},{\"wildcard\":{\"name\":\"*f'*\"}}],\"should\":[{\"match\":{\"name\":\"nestl\"}},{\"match\":{\"name\":\"f'\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -259,26 +275,31 @@ public class TestElasticRql
          assertNull(dsl.getTerm());
          assertNull(dsl.getWildcard());
          assertNotNull(dsl.getBool()); // A bool is used because comma separated values are valid for all 'with' functions
-         
-         assertNull(dsl.getBool().getFilter());
+
+         assertNotNull(dsl.getBool().getFilter());
          assertNull(dsl.getBool().getMust());
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
-         
-         assertEquals(1, dsl.getBool().getShould().size());
-         assertTrue(dsl.getBool().getShould().get(0) instanceof Wildcard);
-         
-         Wildcard wildcard = (Wildcard)dsl.getBool().getShould().get(0);
+
+         // Filter contains Wildcard for matching
+         assertEquals(1, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+
+         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
 
          assertEquals("city", wildcard.getName());
          assertEquals("*andler", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
 
+         // Should contains MatchQuery for relevance scoring
+         assertEquals(1, dsl.getBool().getShould().size());
+         assertTrue(dsl.getBool().getShould().get(0) instanceof MatchQuery);
+
          ObjectMapper mapper = new ObjectMapper();
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"should\":[{\"wildcard\":{\"city\":\"*andler\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"city\":\"*andler\"}}],\"should\":[{\"match\":{\"city\":\"andler\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -301,26 +322,31 @@ public class TestElasticRql
          assertNull(dsl.getTerm());
          assertNull(dsl.getWildcard());
          assertNotNull(dsl.getBool()); // A bool is used because comma separated values are valid for all 'with' functions
-         
-         assertNull(dsl.getBool().getFilter());
+
+         assertNotNull(dsl.getBool().getFilter());
          assertNull(dsl.getBool().getMust());
          assertNull(dsl.getBool().getMustNot());
          assertNotNull(dsl.getBool().getShould());
-         
-         assertEquals(1, dsl.getBool().getShould().size());
-         assertTrue(dsl.getBool().getShould().get(0) instanceof Wildcard);
-         
-         Wildcard wildcard = (Wildcard)dsl.getBool().getShould().get(0);
+
+         // Filter contains Wildcard for matching
+         assertEquals(1, dsl.getBool().getFilter().size());
+         assertTrue(dsl.getBool().getFilter().get(0) instanceof Wildcard);
+
+         Wildcard wildcard = (Wildcard)dsl.getBool().getFilter().get(0);
 
          assertEquals("city", wildcard.getName());
          assertEquals("*andl*", wildcard.getValue());
          assertNull(wildcard.getNestedPath());
 
+         // Should contains MatchQuery for relevance scoring
+         assertEquals(1, dsl.getBool().getShould().size());
+         assertTrue(dsl.getBool().getShould().get(0) instanceof MatchQuery);
+
          ObjectMapper mapper = new ObjectMapper();
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"should\":[{\"wildcard\":{\"city\":\"*andl*\"}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"wildcard\":{\"city\":\"*andl*\"}}],\"should\":[{\"match\":{\"city\":\"andl\"}}]}}", json);
 
       }
       catch (Exception e)
@@ -1248,7 +1274,7 @@ public class TestElasticRql
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"filter\":[{\"nested\":{\"path\":\"keywords\",\"query\":{\"bool\":{\"filter\":[{\"term\":{\"keywords.name\":\"items.name\"}},{\"bool\":{\"should\":[{\"wildcard\":{\"keywords.value\":\"*Powerade*\"}}]}}]}}}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"nested\":{\"path\":\"keywords\",\"query\":{\"bool\":{\"filter\":[{\"term\":{\"keywords.name\":\"items.name\"}},{\"bool\":{\"filter\":[{\"wildcard\":{\"keywords.value\":\"*Powerade*\"}}],\"should\":[{\"match\":{\"keywords.value\":\"Powerade\"}}]}}]}}}}]}}", json);
 
       }
       catch (Exception e)
@@ -1269,7 +1295,7 @@ public class TestElasticRql
          String json = mapper.writeValueAsString(dsl);
 
          assertNotNull("json should not be empty.", json);
-         assertEquals("{\"bool\":{\"filter\":[{\"nested\":{\"path\":\"keywords\",\"query\":{\"bool\":{\"filter\":[{\"bool\":{\"should\":[{\"wildcard\":{\"keywords.value\":\"*Powerade*\"}}]}},{\"term\":{\"keywords.name\":\"items.name\"}}]}}}}]}}", json);
+         assertEquals("{\"bool\":{\"filter\":[{\"nested\":{\"path\":\"keywords\",\"query\":{\"bool\":{\"filter\":[{\"bool\":{\"filter\":[{\"wildcard\":{\"keywords.value\":\"*Powerade*\"}}],\"should\":[{\"match\":{\"keywords.value\":\"Powerade\"}}]}},{\"term\":{\"keywords.name\":\"items.name\"}}]}}}}]}}", json);
 
       }
       catch (Exception e)


### PR DESCRIPTION
## Summary

- Adds `MatchQuery.java` - new Elasticsearch match query DSL class
- Modifies `withWildCardPopulater()` to generate hybrid queries with both wildcard (filter) and match (should)
- Updates BoolQuery to handle MatchQuery serialization

## Problem

Multi-word searches like "pb promo" returned results in arbitrary order because wildcard queries don't contribute to Elasticsearch scoring - they're binary (match/no-match) and produce constant scores.

## Solution: Hybrid Query Approach

**Before (wildcard only):**
```json
{
  "bool": {
    "should": [
      {"wildcard": {"keywords": "*pb*"}},
      {"wildcard": {"keywords": "*promo*"}}
    ]
  }
}
```

**After (hybrid filter + should):**
```json
{
  "bool": {
    "filter": [
      {"wildcard": {"keywords": "*pb*"}},
      {"wildcard": {"keywords": "*promo*"}}
    ],
    "should": [
      {"match": {"keywords": "pb"}},
      {"match": {"keywords": "promo"}}
    ]
  }
}
```

### How It Works

| Clause | Query Type | Purpose | Scoring |
|--------|------------|---------|---------|
| `filter` | Wildcard | Ensures substring exists | None (binary) |
| `should` | Match | Boosts exact token matches | TF-IDF/BM25 |

### Why This Approach

1. **Backwards Compatible** - same documents match
2. **Standard Elasticsearch Pattern** - documented approach
3. **No Reindexing** - works with existing `keywords` field

## Test plan

- [ ] CI passes
- [ ] Deploy to dev and test Portal search with multi-word queries
- [ ] Confirm "pb promo" returns exact matches ranked higher