### PR TITLE
LIFT-2452: Restore async FirehoseClient to fix player disconnections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [0.3.6.18 - 04/27/26]
+- LIFT-2452: Restore async (fire-and-forget) Firehose client to fix Tomcat thread blocking causing player disconnections
+
 ## [0.3.6.17 - 04/05/26]
 - LIFT-2099: Add relevance scoring to wildcard search queries (w, sw, ew operators)
   - Wildcard queries now include match queries in `should` for TF-IDF/BM25 relevance scoring

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.docsDirName='../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.6.17'
+version = '0.3.6.18'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
@@ -5,8 +5,8 @@ import org.atteo.evo.inflector.English;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.firehose.FirehoseClient;
-import software.amazon.awssdk.services.firehose.FirehoseClientBuilder;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClientBuilder;
 
 import io.forty11.j.J;
 import io.rcktapp.api.Collection;
@@ -31,12 +31,12 @@ public class FirehoseDb extends Db
     */
    protected String includeStreams;
 
-   FirehoseClient firehoseClient = null;
+   FirehoseAsyncClient firehoseClient = null;
 
    @Override
    public void bootstrapApi() throws Exception
    {
-      FirehoseClient firehoseClient = getFirehoseClient();
+      FirehoseAsyncClient firehoseClient = getFirehoseClient();
 
       this.setType("firehose");
 
@@ -78,7 +78,7 @@ public class FirehoseDb extends Db
       }
    }
 
-   public FirehoseClient getFirehoseClient()
+   public FirehoseAsyncClient getFirehoseClient()
    {
       if (this.firehoseClient == null)
       {
@@ -86,7 +86,7 @@ public class FirehoseDb extends Db
          {
             if (this.firehoseClient == null)
             {
-               FirehoseClientBuilder builder = FirehoseClient.builder();
+               FirehoseAsyncClientBuilder builder = FirehoseAsyncClient.builder();
                if (!J.empty(awsRegion))
                   builder.region(Region.of(awsRegion));
 

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
@@ -1,7 +1,7 @@
 package io.rcktapp.api.handler.firehose;
 
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
 import software.amazon.awssdk.services.firehose.model.Record;
 import io.forty11.web.js.JSArray;
@@ -65,7 +65,7 @@ public class FirehosePostHandler implements Handler
         Table table = col.getEntity().getTable();
         String streamName = table.getName();
 
-        FirehoseClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
+        FirehoseAsyncClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
 
         JSObject body = req.getJson();
 


### PR DESCRIPTION
## Summary

- Restores fire-and-forget async Firehose behaviour lost during the LIFT-1806 AWS SDK v2 migration
- Swaps `FirehoseClient` (sync) for `FirehoseAsyncClient` (async) in `FirehoseDb` — `putRecordBatch()` on the async client returns a `CompletableFuture` that is intentionally not awaited, so Tomcat threads are never blocked on the Firehose HTTP round-trip
- Bumps version to `0.3.6.18`

## Root Cause

The original SDK v1 code explicitly used `AmazonKinesisFirehoseAsync` and `putRecordBatchAsync()`. The LIFT-1806 migration switched to the synchronous `FirehoseClient`, silently blocking every event POST on the Firehose round-trip. Players have a ~10s read timeout, causing widespread disconnections.

**Prod impact confirmed (last 24h, `ecs/prod/player/snooze/event-api`):**
- ~1,886 `request very slow: FirehosePostHandler_POST_events` warnings
- ~3,871 `ClientAbortException: SocketTimeoutException`

## Test plan

- [x] Build passes (`./gradlew test`)
- [ ] Deploy to dev/e2e and confirm `request very slow` warnings and `SocketTimeoutException` errors drop to zero on the event API
- [ ] Confirm Firehose stream delivery is unaffected (records still arriving in S3/Redshift)