### PR TITLE
LIFT-2453: Restore async FirehoseClient to fix player disconnections (0.3.x)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [0.3.27 - 04/27/26]
+- LIFT-2453: Restore async (fire-and-forget) Firehose client to fix Tomcat thread blocking causing player disconnections
+
 ## [0.3.26 - 03/30/26]
 - LIFT-1807: Upgrade RDS IAM auth token generation to AWS SDK v2
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ project.docsDirName = '../docs/0.3.x/'
 
 configurations.all { resolutionStrategy.cacheChangingModulesFor 0, 'seconds' }
 
-version = '0.3.26'
+version = '0.3.27'
 group = 'com.github.RocketPartners'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehoseDb.java
@@ -3,8 +3,8 @@ package io.rcktapp.api.handler.firehose;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.firehose.FirehoseClient;
-import software.amazon.awssdk.services.firehose.FirehoseClientBuilder;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClientBuilder;
 import software.amazon.awssdk.services.firehose.model.DeliveryStreamType;
 import software.amazon.awssdk.services.firehose.model.ListDeliveryStreamsRequest;
 import software.amazon.awssdk.services.firehose.model.ListDeliveryStreamsResponse;
@@ -48,7 +48,7 @@ public class FirehoseDb extends Db
      */
     protected String includeStreams;
 
-    FirehoseClient firehoseClient = null;
+    FirehoseAsyncClient firehoseClient = null;
 
     public FirehoseDb() {
         super();
@@ -111,7 +111,7 @@ public class FirehoseDb extends Db
 
             ListDeliveryStreamsRequest listDeliveryStreamsRequest = getRequest(last);
 
-            listDeliveryStreamsResponse = getFirehoseClient().listDeliveryStreams(listDeliveryStreamsRequest);
+            listDeliveryStreamsResponse = getFirehoseClient().listDeliveryStreams(listDeliveryStreamsRequest).join();
 
             deliveryStreamNames.addAll(listDeliveryStreamsResponse.deliveryStreamNames());
 
@@ -129,11 +129,11 @@ public class FirehoseDb extends Db
         return builder.build();
     }
 
-    public FirehoseClient getFirehoseClient() {
+    public FirehoseAsyncClient getFirehoseClient() {
         if (this.firehoseClient == null) {
             synchronized (this) {
                 if (this.firehoseClient == null) {
-                    FirehoseClientBuilder builder = FirehoseClient.builder();
+                    FirehoseAsyncClientBuilder builder = FirehoseAsyncClient.builder();
                     if (!J.empty(awsRegion))
                         builder.region(Region.of(awsRegion));
 

--- a/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
+++ b/src/main/java/io/rcktapp/api/handler/firehose/FirehosePostHandler.java
@@ -1,7 +1,7 @@
 package io.rcktapp.api.handler.firehose;
 
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
 import software.amazon.awssdk.services.firehose.model.Record;
 import io.forty11.web.js.JSArray;
@@ -65,7 +65,7 @@ public class FirehosePostHandler implements Handler
         Table table = col.getEntity().getTable();
         String streamName = table.getName();
 
-        FirehoseClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
+        FirehoseAsyncClient firehose = ((FirehoseDb) table.getDb()).getFirehoseClient();
 
         JSObject body = req.getJson();
 


### PR DESCRIPTION
## Summary

- Restores fire-and-forget async Firehose behaviour on `release-0.3.x`, lost during the LIFT-1806 AWS SDK v2 migration
- Swaps `FirehoseClient` (sync) for `FirehoseAsyncClient` (async) in `FirehoseDb` — `putRecordBatch()` on the async client returns a `CompletableFuture` that is intentionally not awaited at request time
- `listDeliveryStreams()` in `bootstrapApi()` calls `.join()` since it is a one-time startup operation where blocking is acceptable
- Bumps version to `0.3.27`

## Related

- LIFT-2452 / PR #216: same fix already applied to `release-0.3.6.x`
- `liftck_heartbeat` depends on `rocket-inversion:0.3.26` — once this is merged and published, heartbeat should be updated to `0.3.27`

## Test plan

- [x] Build passes (`./gradlew test`)
- [ ] `liftck_heartbeat` updated to `0.3.27` and deployed to dev/e2e
- [ ] Confirm `request very slow` warnings and `SocketTimeoutException` errors drop to zero
- [ ] Confirm Firehose stream delivery is unaffected